### PR TITLE
Add Grafik element service interface

### DIFF
--- a/data/repositories/grafik_element_repository.dart
+++ b/data/repositories/grafik_element_repository.dart
@@ -1,9 +1,9 @@
 import '../../domain/models/grafik/enums.dart';
 import '../../domain/models/grafik/grafik_element.dart';
-import '../services/grafik_element_firebase_service.dart';
+import '../../domain/services/i_grafik_element_service.dart';
 
 class GrafikElementRepository {
-  final GrafikElementFirebaseService _service;
+  final IGrafikElementService _service;
   GrafikElementRepository(this._service);
 
   // ⚠️  teraz korzystamy z wersji „z pendingami”

--- a/data/services/grafik_element_firebase_service.dart
+++ b/data/services/grafik_element_firebase_service.dart
@@ -3,8 +3,9 @@ import 'package:rxdart/rxdart.dart'; //  ⬅️ NOWE!
 import '../../domain/models/grafik/enums.dart';
 import '../../domain/models/grafik/grafik_element.dart';
 import '../../domain/models/grafik/grafik_element_registry.dart';
+import '../../domain/services/i_grafik_element_service.dart';
 
-class GrafikElementFirebaseService {
+class GrafikElementFirebaseService implements IGrafikElementService {
   final FirebaseFirestore _firestore;
 
   GrafikElementFirebaseService(this._firestore);

--- a/domain/services/i_grafik_element_service.dart
+++ b/domain/services/i_grafik_element_service.dart
@@ -1,0 +1,28 @@
+import '../models/grafik/enums.dart';
+import '../models/grafik/grafik_element.dart';
+
+abstract class IGrafikElementService {
+  Stream<List<GrafikElement>> getGrafikElementsWithinRange({
+    required DateTime start,
+    required DateTime end,
+    List<String>? types,
+  });
+
+  Stream<List<GrafikElement>> getPendingTaskPlannings();
+
+  Stream<List<GrafikElement>> getGrafikElementsWithinRangeIncludingPending({
+    required DateTime start,
+    required DateTime end,
+    List<String>? types,
+  });
+
+  Future<void> upsertGrafikElement(GrafikElement element);
+
+  Future<void> updateGrafikElementField(String id, Map<String, dynamic> data);
+
+  Future<void> updateTaskStatus(String id, GrafikStatus status);
+
+  Future<void> upsertManyGrafikElements(List<GrafikElement> elements);
+
+  Future<void> deleteGrafikElement(String id);
+}

--- a/injection.dart
+++ b/injection.dart
@@ -13,6 +13,7 @@ import 'feature/grafik/cubit/grafik_cubit.dart';
 import 'data/repositories/grafik_element_repository.dart';
 import 'data/services/auth_service.dart';
 import 'data/services/grafik_element_firebase_service.dart';
+import 'domain/services/i_grafik_element_service.dart';
 
 final getIt = GetIt.instance;
 
@@ -37,7 +38,7 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<VehicleFirebaseService>(
     () => VehicleFirebaseService(getIt<FirebaseFirestore>()),
   );
-  getIt.registerLazySingleton<GrafikElementFirebaseService>(
+  getIt.registerLazySingleton<IGrafikElementService>(
     () => GrafikElementFirebaseService(getIt<FirebaseFirestore>()),
   );
 
@@ -52,7 +53,7 @@ Future<void> setupLocator() async {
     () => VehicleRepository(getIt<VehicleFirebaseService>()),
   );
   getIt.registerLazySingleton<GrafikElementRepository>(
-    () => GrafikElementRepository(getIt<GrafikElementFirebaseService>()),
+    () => GrafikElementRepository(getIt<IGrafikElementService>()),
   );
 
   //CUBIT


### PR DESCRIPTION
## Summary
- extract `IGrafikElementService` interface into domain layer
- implement the interface in `GrafikElementFirebaseService`
- use the interface in `GrafikElementRepository`
- register the interface in dependency injection

## Testing
- `dart format` *(fails: `dart` not found)*
- `flutter --version` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d19425ac8333ae487584be287107