### PR TITLE
Add Grafik element service interface

### DIFF
--- a/data/repositories/app_user_repository.dart
+++ b/data/repositories/app_user_repository.dart
@@ -1,8 +1,8 @@
 import '../../domain/models/app_user.dart';
-import '../services/app_user_firebase_service.dart';
+import '../../domain/services/i_app_user_service.dart';
 
 class AppUserRepository {
-  final AppUserFirebaseService _service;
+  final IAppUserService _service;
 
   AppUserRepository(this._service);
 

--- a/data/repositories/emplyee_repository.dart
+++ b/data/repositories/emplyee_repository.dart
@@ -1,9 +1,9 @@
 
 import '../../domain/models/emplyee.dart';
-import '../services/empleyee_firebase_service.dart';
+import '../../domain/services/i_employee_service.dart';
 
 class EmployeeRepository {
-  final EmployeeFirebaseService _service;
+  final IEmployeeService _service;
 
   EmployeeRepository(this._service);
 

--- a/data/repositories/grafik_element_repository.dart
+++ b/data/repositories/grafik_element_repository.dart
@@ -1,9 +1,9 @@
 import '../../domain/models/grafik/enums.dart';
 import '../../domain/models/grafik/grafik_element.dart';
-import '../services/grafik_element_firebase_service.dart';
+import '../../domain/services/i_grafik_element_service.dart';
 
 class GrafikElementRepository {
-  final GrafikElementFirebaseService _service;
+  final IGrafikElementService _service;
   GrafikElementRepository(this._service);
 
   // ⚠️  teraz korzystamy z wersji „z pendingami”

--- a/data/repositories/vehicle_repository.dart
+++ b/data/repositories/vehicle_repository.dart
@@ -1,8 +1,8 @@
 import '../../domain/models/vehicle.dart';
-import '../services/vehicle_firebase_service.dart';
+import '../../domain/services/i_vehicle_service.dart';
 
 class VehicleRepository {
-  final VehicleFirebaseService _service;
+  final IVehicleService _service;
 
   VehicleRepository(this._service);
 

--- a/data/services/app_user_firebase_service.dart
+++ b/data/services/app_user_firebase_service.dart
@@ -1,7 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/models/app_user.dart';
+import '../../domain/services/i_app_user_service.dart';
 
-class AppUserFirebaseService {
+class AppUserFirebaseService implements IAppUserService {
   final FirebaseFirestore _firestore;
 
   AppUserFirebaseService(this._firestore);

--- a/data/services/empleyee_firebase_service.dart
+++ b/data/services/empleyee_firebase_service.dart
@@ -1,8 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../domain/models/emplyee.dart';
+import '../../domain/services/i_employee_service.dart';
 
-class EmployeeFirebaseService {
+class EmployeeFirebaseService implements IEmployeeService {
   final FirebaseFirestore _firestore;
 
   EmployeeFirebaseService(this._firestore);

--- a/data/services/grafik_element_firebase_service.dart
+++ b/data/services/grafik_element_firebase_service.dart
@@ -3,8 +3,9 @@ import 'package:rxdart/rxdart.dart'; //  ⬅️ NOWE!
 import '../../domain/models/grafik/enums.dart';
 import '../../domain/models/grafik/grafik_element.dart';
 import '../../domain/models/grafik/grafik_element_registry.dart';
+import '../../domain/services/i_grafik_element_service.dart';
 
-class GrafikElementFirebaseService {
+class GrafikElementFirebaseService implements IGrafikElementService {
   final FirebaseFirestore _firestore;
 
   GrafikElementFirebaseService(this._firestore);

--- a/data/services/vehicle_firebase_service.dart
+++ b/data/services/vehicle_firebase_service.dart
@@ -1,7 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/models/vehicle.dart';
+import '../../domain/services/i_vehicle_service.dart';
 
-class VehicleFirebaseService {
+class VehicleFirebaseService implements IVehicleService {
   final FirebaseFirestore _firestore;
 
   VehicleFirebaseService(this._firestore);

--- a/domain/models/grafik/pending_task_column.dart
+++ b/domain/models/grafik/pending_task_column.dart
@@ -13,10 +13,10 @@ class PendingTasksColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<GrafikCubit, GrafikState>(
       buildWhen: (prev, next) =>
-      prev.weekTaskPlanningElements != next.weekTaskPlanningElements,
+      prev.weekData.taskPlannings != next.weekData.taskPlannings,
       builder: (context, state) {
         // filtrowanie tylko "wisi‑grozi"
-        final pending = state.weekTaskPlanningElements
+        final pending = state.weekData.taskPlannings
             .where((e) => e.isPending)
             .toList()
           ..sort(

--- a/domain/services/i_app_user_service.dart
+++ b/domain/services/i_app_user_service.dart
@@ -1,0 +1,6 @@
+import '../models/app_user.dart';
+
+abstract class IAppUserService {
+  Future<void> upsertAppUser(AppUser user);
+  Stream<AppUser?> getAppUserStream(String uid);
+}

--- a/domain/services/i_employee_service.dart
+++ b/domain/services/i_employee_service.dart
@@ -1,0 +1,6 @@
+import '../models/emplyee.dart';
+
+abstract class IEmployeeService {
+  Stream<List<Employee>> getEmployeesStream();
+  Future<void> upsertEmployee(Employee employee);
+}

--- a/domain/services/i_grafik_element_service.dart
+++ b/domain/services/i_grafik_element_service.dart
@@ -1,0 +1,28 @@
+import '../models/grafik/enums.dart';
+import '../models/grafik/grafik_element.dart';
+
+abstract class IGrafikElementService {
+  Stream<List<GrafikElement>> getGrafikElementsWithinRange({
+    required DateTime start,
+    required DateTime end,
+    List<String>? types,
+  });
+
+  Stream<List<GrafikElement>> getPendingTaskPlannings();
+
+  Stream<List<GrafikElement>> getGrafikElementsWithinRangeIncludingPending({
+    required DateTime start,
+    required DateTime end,
+    List<String>? types,
+  });
+
+  Future<void> upsertGrafikElement(GrafikElement element);
+
+  Future<void> updateGrafikElementField(String id, Map<String, dynamic> data);
+
+  Future<void> updateTaskStatus(String id, GrafikStatus status);
+
+  Future<void> upsertManyGrafikElements(List<GrafikElement> elements);
+
+  Future<void> deleteGrafikElement(String id);
+}

--- a/domain/services/i_vehicle_service.dart
+++ b/domain/services/i_vehicle_service.dart
@@ -1,0 +1,6 @@
+import '../models/vehicle.dart';
+
+abstract class IVehicleService {
+  Stream<List<Vehicle>> getVehiclesStream();
+  Future<void> upsertVehicle(Vehicle vehicle);
+}

--- a/feature/grafik/cubit/form/grafik_element_form_cubit.dart
+++ b/feature/grafik/cubit/form/grafik_element_form_cubit.dart
@@ -12,43 +12,7 @@ import '../../../../domain/models/grafik/impl/task_template.dart';
 import '../../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../../main.dart';
 import '../../widget/dialog/worker_conflict_popup.dart';
-
-// ───────── STANY ─────────
-abstract class GrafikElementFormState {}
-
-class GrafikElementFormInitial extends GrafikElementFormState {}
-
-class GrafikElementFormEditing extends GrafikElementFormState {
-  final GrafikElement element;
-  final bool isSubmitting;
-  final bool isSuccess;
-  final bool isFailure;
-  final List<String> selectedWorkerIds;
-
-  GrafikElementFormEditing({
-    required this.element,
-    this.isSubmitting = false,
-    this.isSuccess = false,
-    this.isFailure = false,
-    this.selectedWorkerIds = const [],
-  });
-
-  GrafikElementFormEditing copyWith({
-    GrafikElement? element,
-    bool? isSubmitting,
-    bool? isSuccess,
-    bool? isFailure,
-    List<String>? selectedWorkerIds,
-  }) {
-    return GrafikElementFormEditing(
-      element: element ?? this.element,
-      isSubmitting: isSubmitting ?? this.isSubmitting,
-      isSuccess: isSuccess ?? this.isSuccess,
-      isFailure: isFailure ?? this.isFailure,
-      selectedWorkerIds: selectedWorkerIds ?? this.selectedWorkerIds,
-    );
-  }
-}
+import 'grafik_element_form_state.dart';
 
 // ───────── CUBIT ─────────
 class GrafikElementFormCubit extends Cubit<GrafikElementFormState> {

--- a/feature/grafik/cubit/form/grafik_element_form_state.dart
+++ b/feature/grafik/cubit/form/grafik_element_form_state.dart
@@ -1,0 +1,37 @@
+import '../../../../domain/models/grafik/grafik_element.dart';
+
+abstract class GrafikElementFormState {}
+
+class GrafikElementFormInitial extends GrafikElementFormState {}
+
+class GrafikElementFormEditing extends GrafikElementFormState {
+  final GrafikElement element;
+  final bool isSubmitting;
+  final bool isSuccess;
+  final bool isFailure;
+  final List<String> selectedWorkerIds;
+
+  GrafikElementFormEditing({
+    required this.element,
+    this.isSubmitting = false,
+    this.isSuccess = false,
+    this.isFailure = false,
+    this.selectedWorkerIds = const [],
+  });
+
+  GrafikElementFormEditing copyWith({
+    GrafikElement? element,
+    bool? isSubmitting,
+    bool? isSuccess,
+    bool? isFailure,
+    List<String>? selectedWorkerIds,
+  }) {
+    return GrafikElementFormEditing(
+      element: element ?? this.element,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      isSuccess: isSuccess ?? this.isSuccess,
+      isFailure: isFailure ?? this.isFailure,
+      selectedWorkerIds: selectedWorkerIds ?? this.selectedWorkerIds,
+    );
+  }
+}

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -192,11 +192,15 @@ class GrafikCubit extends Cubit<GrafikState> {
         };
       },
     ).listen((data) {
+      final updatedWeek = state.weekData.copyWith(
+        taskElements: data['taskElements'] as List<TaskElement>,
+        timeIssues: data['timeIssues'] as List<TimeIssueElement>,
+        taskPlannings: data['taskPlannings'] as List<TaskPlanningElement>,
+        deliveryPlannings:
+            data['deliveryPlanningElements'] as List<DeliveryPlanningElement>,
+      );
       emit(state.copyWith(
-        weekTaskElements: data['taskElements'] as List<TaskElement>,
-        weekTaskIssueElements: data['timeIssues'] as List<TimeIssueElement>,
-        weekTaskPlanningElements: data['taskPlannings'] as List<TaskPlanningElement>,
-        weekDeliveryPlanningElements: data['deliveryPlanningElements'] as List<DeliveryPlanningElement>,
+        weekData: updatedWeek,
         employees: data['employees'] as List<Employee>,
       ));
     }, onError: (e) {

--- a/feature/grafik/cubit/grafik_state.dart
+++ b/feature/grafik/cubit/grafik_state.dart
@@ -1,9 +1,8 @@
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
-import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
-import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
 import 'package:kabast/domain/models/vehicle.dart';
 import 'package:kabast/domain/models/emplyee.dart';
+import 'states/week_grafik_data.dart';
 
 class GrafikState {
   final List<TaskElement> tasks;
@@ -16,10 +15,7 @@ class GrafikState {
   final DateTime selectedDayInWeekView; // nowa właściwość
   final String? error;
 
-  final List<TaskElement> weekTaskElements;
-  final List<TimeIssueElement> weekTimeIssueElements;
-  final List<TaskPlanningElement> weekTaskPlanningElements;
-  final List<DeliveryPlanningElement> weekDeliveryPlanningElements;
+  final WeekGrafikData weekData;
 
   GrafikState({
     required this.tasks,
@@ -31,10 +27,7 @@ class GrafikState {
     required this.selectedDay,
     required this.selectedDayInWeekView,
     this.error,
-    required this.weekTaskElements,
-    required this.weekTimeIssueElements,
-    required this.weekTaskPlanningElements,
-    required this.weekDeliveryPlanningElements,
+    required this.weekData,
   });
 
   factory GrafikState.initial() {
@@ -51,10 +44,7 @@ class GrafikState {
       selectedDay: now,
       selectedDayInWeekView: monday,
       error: null,
-      weekTaskElements: [],
-      weekTimeIssueElements: [],
-      weekTaskPlanningElements: [],
-      weekDeliveryPlanningElements: [],
+      weekData: WeekGrafikData.initial(),
     );
   }
 
@@ -68,10 +58,7 @@ class GrafikState {
     DateTime? selectedDay,
     DateTime? selectedDayInWeekView,
     String? error,
-    List<TaskElement>? weekTaskElements,
-    List<TimeIssueElement>? weekTaskIssueElements,
-    List<TaskPlanningElement>? weekTaskPlanningElements,
-    List<DeliveryPlanningElement>? weekDeliveryPlanningElements,
+    WeekGrafikData? weekData,
   }) {
     return GrafikState(
       tasks: tasks ?? this.tasks,
@@ -83,10 +70,7 @@ class GrafikState {
       selectedDay: selectedDay ?? this.selectedDay,
       selectedDayInWeekView: selectedDayInWeekView ?? this.selectedDayInWeekView,
       error: error ?? this.error,
-      weekTaskElements: weekTaskElements ?? this.weekTaskElements,
-      weekTimeIssueElements: weekTaskIssueElements ?? this.weekTimeIssueElements,
-      weekTaskPlanningElements: weekTaskPlanningElements ?? this.weekTaskPlanningElements,
-      weekDeliveryPlanningElements: weekDeliveryPlanningElements ?? this.weekDeliveryPlanningElements,
+      weekData: weekData ?? this.weekData,
     );
   }
 }

--- a/feature/grafik/cubit/states/week_grafik_data.dart
+++ b/feature/grafik/cubit/states/week_grafik_data.dart
@@ -1,0 +1,39 @@
+import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
+import 'package:kabast/domain/models/grafik/impl/task_element.dart';
+import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
+import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
+
+class WeekGrafikData {
+  final List<TaskElement> taskElements;
+  final List<TimeIssueElement> timeIssues;
+  final List<TaskPlanningElement> taskPlannings;
+  final List<DeliveryPlanningElement> deliveryPlannings;
+
+  WeekGrafikData({
+    required this.taskElements,
+    required this.timeIssues,
+    required this.taskPlannings,
+    required this.deliveryPlannings,
+  });
+
+  factory WeekGrafikData.initial() => WeekGrafikData(
+        taskElements: [],
+        timeIssues: [],
+        taskPlannings: [],
+        deliveryPlannings: [],
+      );
+
+  WeekGrafikData copyWith({
+    List<TaskElement>? taskElements,
+    List<TimeIssueElement>? timeIssues,
+    List<TaskPlanningElement>? taskPlannings,
+    List<DeliveryPlanningElement>? deliveryPlannings,
+  }) {
+    return WeekGrafikData(
+      taskElements: taskElements ?? this.taskElements,
+      timeIssues: timeIssues ?? this.timeIssues,
+      taskPlannings: taskPlannings ?? this.taskPlannings,
+      deliveryPlannings: deliveryPlannings ?? this.deliveryPlannings,
+    );
+  }
+}

--- a/feature/grafik/form/components/date_input_selector.dart
+++ b/feature/grafik/form/components/date_input_selector.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../domain/models/grafik/enums.dart';
+import '../../../../domain/models/grafik/grafik_element.dart';
+import '../../../../domain/models/grafik/impl/task_planning_element.dart';
+import '../../../../domain/models/grafik/impl/time_issue_element.dart';
+import '../../../shared/datetime/date_range_picker_button.dart';
+import '../../../shared/datetime/date_time_picker_field.dart';
+import '../../cubit/form/grafik_element_form_cubit.dart';
+
+class DateInputSelector extends StatelessWidget {
+  final GrafikElement element;
+
+  const DateInputSelector({super.key, required this.element});
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isTaskPlanning = element is TaskPlanningElement;
+    final bool isPending = isTaskPlanning
+        ? (element as TaskPlanningElement).isPending
+        : false;
+
+    if (isTaskPlanning && isPending) {
+      return const Padding(
+        padding: EdgeInsets.only(bottom: 8.0),
+        child: Text(
+          'Wisi i grozi – brak terminu',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+      );
+    }
+
+    if (isTaskPlanning ||
+        (element is TimeIssueElement &&
+            element.issueType == TimeIssueType.Nieobecnosc)) {
+      return DateRangePickerButton(
+        initialRange: DateTimeRange(
+          start: element.startDateTime,
+          end: element.endDateTime,
+        ),
+        onRangeSelected: (range) {
+          context.read<GrafikElementFormCubit>()
+              .updateField('startDateTime', range.start);
+          context.read<GrafikElementFormCubit>()
+              .updateField('endDateTime', range.end);
+        },
+      );
+    }
+
+    return DateTimePickerField(
+      initialDate: element.startDateTime,
+      initialStartHour: element.startDateTime.hour.toDouble(),
+      initialEndHour: element.endDateTime.hour.toDouble(),
+      onChanged: (range) {
+        context
+            .read<GrafikElementFormCubit>()
+            .updateField('startDateTime', range.start);
+        context
+            .read<GrafikElementFormCubit>()
+            .updateField('endDateTime', range.end);
+      },
+    );
+  }
+}

--- a/feature/grafik/form/components/type_dropdown.dart
+++ b/feature/grafik/form/components/type_dropdown.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../domain/models/grafik/grafik_element.dart';
+import '../../../../domain/models/grafik/grafik_element_registry.dart';
+import '../../cubit/form/grafik_element_form_cubit.dart';
+
+class TypeDropdown extends StatelessWidget {
+  final GrafikElement element;
+  const TypeDropdown({super.key, required this.element});
+
+  @override
+  Widget build(BuildContext context) {
+    final types = GrafikElementRegistry.getRegisteredTypes();
+    final mapping = {
+      'TaskElement': 'Zadanie',
+      'TaskPlanningElement': 'Planowane zadanie',
+      'TimeIssueElement': 'Czas Pracy',
+      'DeliveryPlanningElement': 'Dostawa',
+    };
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        DropdownButton<String>(
+          value: element.type,
+          underline: const SizedBox(),
+          icon: const Icon(
+            Icons.arrow_drop_down,
+            color: Colors.blueAccent,
+            size: 42.0,
+          ),
+          items: types.map((t) {
+            return DropdownMenuItem(
+              value: t,
+              child: Text(
+                mapping[t] ?? t,
+                style: const TextStyle(color: Colors.black),
+              ),
+            );
+          }).toList(),
+          onChanged: (val) {
+            if (val != null) {
+              context.read<GrafikElementFormCubit>().updateField('type', val);
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -25,10 +25,10 @@ class ForegroundLayer extends StatelessWidget {
         // Używamy selectedDayInWeekView jako daty początkowej
         final startDate = state.selectedDayInWeekView;
         final planningElements = <GrafikElement>[
-          ...state.weekTaskPlanningElements,
-          ...state.weekDeliveryPlanningElements,
-          ...state.weekTaskElements,
-          ...state.weekTimeIssueElements,
+          ...state.weekData.taskPlannings,
+          ...state.weekData.deliveryPlannings,
+          ...state.weekData.taskElements,
+          ...state.weekData.timeIssues,
         ];
 
         return GrafikGrid(

--- a/feature/grafik/widget/week/time_issue_chip_list_panel.dart
+++ b/feature/grafik/widget/week/time_issue_chip_list_panel.dart
@@ -13,7 +13,7 @@ class TimeIssueChipListPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<GrafikCubit, GrafikState>(
       builder: (context, state) {
-        final issues = state.weekTimeIssueElements;
+        final issues = state.weekData.timeIssues;
         final employees = state.employees;
 
         final List<Widget> chips = [];

--- a/injection.dart
+++ b/injection.dart
@@ -13,6 +13,10 @@ import 'feature/grafik/cubit/grafik_cubit.dart';
 import 'data/repositories/grafik_element_repository.dart';
 import 'data/services/auth_service.dart';
 import 'data/services/grafik_element_firebase_service.dart';
+import 'domain/services/i_grafik_element_service.dart';
+import 'domain/services/i_app_user_service.dart';
+import 'domain/services/i_employee_service.dart';
+import 'domain/services/i_vehicle_service.dart';
 
 final getIt = GetIt.instance;
 
@@ -28,31 +32,31 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<AuthService>(
     () => AuthService(getIt<FirebaseAuth>()),
   );
-  getIt.registerLazySingleton<AppUserFirebaseService>(
+  getIt.registerLazySingleton<IAppUserService>(
     () => AppUserFirebaseService(getIt<FirebaseFirestore>()),
   );
-  getIt.registerLazySingleton<EmployeeFirebaseService>(
+  getIt.registerLazySingleton<IEmployeeService>(
     () => EmployeeFirebaseService(getIt<FirebaseFirestore>()),
   );
-  getIt.registerLazySingleton<VehicleFirebaseService>(
+  getIt.registerLazySingleton<IVehicleService>(
     () => VehicleFirebaseService(getIt<FirebaseFirestore>()),
   );
-  getIt.registerLazySingleton<GrafikElementFirebaseService>(
+  getIt.registerLazySingleton<IGrafikElementService>(
     () => GrafikElementFirebaseService(getIt<FirebaseFirestore>()),
   );
 
   // Repozytoria
   getIt.registerLazySingleton<AppUserRepository>(
-    () => AppUserRepository(getIt<AppUserFirebaseService>()),
+    () => AppUserRepository(getIt<IAppUserService>()),
   );
   getIt.registerLazySingleton<EmployeeRepository>(
-    () => EmployeeRepository(getIt<EmployeeFirebaseService>()),
+    () => EmployeeRepository(getIt<IEmployeeService>()),
   );
   getIt.registerLazySingleton<VehicleRepository>(
-    () => VehicleRepository(getIt<VehicleFirebaseService>()),
+    () => VehicleRepository(getIt<IVehicleService>()),
   );
   getIt.registerLazySingleton<GrafikElementRepository>(
-    () => GrafikElementRepository(getIt<GrafikElementFirebaseService>()),
+    () => GrafikElementRepository(getIt<IGrafikElementService>()),
   );
 
   //CUBIT


### PR DESCRIPTION
## Summary
- extract `IGrafikElementService` interface into domain layer
- implement the interface in `GrafikElementFirebaseService`
- use the interface in `GrafikElementRepository`
- register the interface in dependency injection
- introduce interfaces for other Firebase services and update repositories
- split large grafik-related files into smaller components

## Testing
- `dart format` *(fails: `dart` not found)*
- `flutter --version` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d19425ac8333ae487584be287107