### PR TITLE
Remove serialization logic from TaskPlanningElement

### DIFF
--- a/domain/models/grafik/impl/task_planning_element.dart
+++ b/domain/models/grafik/impl/task_planning_element.dart
@@ -1,5 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import '../../../constants/pending_placeholder_date.dart';
 import '../enums.dart';
 import '../grafik_element.dart';
 
@@ -42,79 +40,4 @@ class TaskPlanningElement extends GrafikElement {
     closed: closed,
   );
 
-  @override
-  Map<String, dynamic> toJson() {
-    final base = baseToJson();
-    return {
-      ...base,
-      'workerCount': workerCount,
-      'orderId': orderId,
-      'probability': probability.toString(),
-      'taskType': taskType.toString(),
-      'minutes': minutes,
-      'highPriority': highPriority,
-      'workerIds': workerIds,
-      'isPending': isPending, // 👈 nowy klucz
-    };
-  }
-
-  factory TaskPlanningElement.fromJson(Map<String, dynamic> json) {
-    final id = (json['id'] as String?) ?? '';
-    final startTs = json['startDateTime'] as Timestamp?;
-    final endTs = json['endDateTime'] as Timestamp?;
-    final additionalInfo = (json['additionalInfo'] as String?) ?? '';
-    final addedByUserId = (json['addedByUserId'] as String?) ?? '';
-    final addedTimestamp =
-        (json['addedTimestamp'] as Timestamp?)?.toDate() ?? DateTime(1960, 2, 9);
-    final closed = (json['closed'] as bool?) ?? false;
-
-    final workerCount = (json['workerCount'] as int?) ?? 1;
-    final orderId = (json['orderId'] as String?) ?? '';
-
-    final probabilityStr =
-        (json['probability'] as String?) ?? 'GrafikProbability.Pewne';
-    final probability = GrafikProbability.values.firstWhere(
-          (e) => e.toString() == probabilityStr,
-      orElse: () => GrafikProbability.Pewne,
-    );
-
-    final taskTypeStr =
-        (json['taskType'] as String?) ?? 'GrafikTaskType.Inne';
-    final taskType = GrafikTaskType.values.firstWhere(
-          (e) => e.toString() == taskTypeStr,
-      orElse: () => GrafikTaskType.Inne,
-    );
-
-    final minutes = (json['minutes'] as int?) ?? 60;
-    final highPriority = (json['highPriority'] as bool?) ?? false;
-
-    final workerIdsRaw = json['workerIds'];
-    final workerIds = workerIdsRaw == null
-        ? <String>[]
-        : List<String>.from(workerIdsRaw as List);
-
-    final isPending = (json['isPending'] as bool?) ?? false;
-
-    return TaskPlanningElement(
-      id: id,
-      startDateTime: isPending
-          ? pendingPlaceholderDate
-          : startTs?.toDate() ?? DateTime.now(),
-      endDateTime: isPending
-          ? pendingPlaceholderDate.add(Duration(minutes: 60))
-          : endTs?.toDate() ?? DateTime.now(),
-      additionalInfo: additionalInfo,
-      workerCount: workerCount,
-      orderId: orderId,
-      probability: probability,
-      taskType: taskType,
-      minutes: minutes,
-      highPriority: highPriority,
-      workerIds: workerIds,
-      addedByUserId: addedByUserId,
-      addedTimestamp: addedTimestamp,
-      closed: closed,
-      isPending: isPending,
-    );
-  }
 }


### PR DESCRIPTION
## Summary
- refactor `TaskPlanningElement` model to drop JSON/Firestore methods and imports

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657ebfd0d083339f5ea0199d29dda3