### PR TITLE
Refactor domain models and move serialization to DTOs

### DIFF
--- a/data/dto/app_user_dto.dart
+++ b/data/dto/app_user_dto.dart
@@ -1,0 +1,113 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/app_user.dart';
+
+class AppUserDto {
+  final String id;
+  final String email;
+  final String fullName;
+  final String employeeId;
+  final UserRole role;
+  final Map<String, bool> permissionsOverride;
+
+  AppUserDto({
+    required this.id,
+    required this.email,
+    required this.fullName,
+    required this.employeeId,
+    required this.role,
+    required this.permissionsOverride,
+  });
+
+  factory AppUserDto.fromJson(Map<String, dynamic> json) {
+    return AppUserDto(
+      id: json['id'] as String? ?? '',
+      email: json['email'] as String? ?? '',
+      fullName: json['fullName'] as String? ?? '',
+      employeeId: json['employeeId'] as String? ?? '',
+      role: _stringToUserRole(json['role'] as String?),
+      permissionsOverride: (json['permissionsOverride'] as Map?)?.map((key, value) => MapEntry(key.toString(), value as bool)) ?? {},
+    );
+  }
+
+  factory AppUserDto.fromFirestore(DocumentSnapshot doc) {
+    final data = (doc.data() as Map<String, dynamic>? ?? {})..putIfAbsent('id', () => doc.id);
+    return AppUserDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'fullName': fullName,
+      'employeeId': employeeId,
+      'role': _userRoleToString(role),
+      'permissionsOverride': permissionsOverride,
+    };
+  }
+
+  AppUser toDomain() {
+    return AppUser(
+      id: id,
+      email: email,
+      fullName: fullName,
+      employeeId: employeeId,
+      role: role,
+      permissionsOverride: permissionsOverride,
+    );
+  }
+
+  factory AppUserDto.fromDomain(AppUser user) {
+    return AppUserDto(
+      id: user.id,
+      email: user.email,
+      fullName: user.fullName,
+      employeeId: user.employeeId,
+      role: user.role,
+      permissionsOverride: user.permissionsOverride,
+    );
+  }
+}
+
+UserRole _stringToUserRole(String? value) {
+  switch (value) {
+    case 'admin':
+      return UserRole.admin;
+    case 'czlonekZarzadu':
+      return UserRole.czlonekZarzadu;
+    case 'czlowiekZarzadu':
+      return UserRole.czlowiekZarzadu;
+    case 'kierownik':
+      return UserRole.kierownik;
+    case 'kierownikProdukcji':
+      return UserRole.kierownikProdukcji;
+    case 'monter':
+      return UserRole.monter;
+    case 'hala':
+      return UserRole.hala;
+    case 'user':
+      return UserRole.user;
+    default:
+      return UserRole.user;
+  }
+}
+
+String _userRoleToString(UserRole role) {
+  switch (role) {
+    case UserRole.admin:
+      return 'admin';
+    case UserRole.czlonekZarzadu:
+      return 'czlonekZarzadu';
+    case UserRole.czlowiekZarzadu:
+      return 'czlowiekZarzadu';
+    case UserRole.kierownik:
+      return 'kierownik';
+    case UserRole.kierownikProdukcji:
+      return 'kierownikProdukcji';
+    case UserRole.monter:
+      return 'monter';
+    case UserRole.hala:
+      return 'hala';
+    case UserRole.user:
+      return 'user';
+  }
+}

--- a/data/dto/employee_dto.dart
+++ b/data/dto/employee_dto.dart
@@ -1,0 +1,44 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/employee.dart';
+
+class EmployeeDto {
+  final String uid;
+  final String role;
+  final String fullName;
+
+  EmployeeDto({required this.uid, required this.role, required this.fullName});
+
+  factory EmployeeDto.fromJson(Map<String, dynamic> json) {
+    String getValue(String key, {String defaultValue = ''}) {
+      final value = json[key];
+      return value?.toString() ?? defaultValue;
+    }
+
+    return EmployeeDto(
+      uid: getValue('uid'),
+      role: getValue('role', defaultValue: 'worker'),
+      fullName: getValue('fullName', defaultValue: 'Anonimowy Pracownik'),
+    );
+  }
+
+  factory EmployeeDto.fromFirestore(DocumentSnapshot doc) {
+    final data = (doc.data() as Map<String, dynamic>? ?? {})..putIfAbsent('uid', () => doc.id);
+    return EmployeeDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'uid': uid,
+      'role': role,
+      'fullName': fullName,
+    };
+  }
+
+  Employee toDomain() {
+    return Employee(uid: uid, role: role, fullName: fullName);
+  }
+
+  factory EmployeeDto.fromDomain(Employee employee) {
+    return EmployeeDto(uid: employee.uid, role: employee.role, fullName: employee.fullName);
+  }
+}

--- a/data/dto/vehicle_dto.dart
+++ b/data/dto/vehicle_dto.dart
@@ -1,0 +1,109 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/vehicle.dart';
+
+class VehicleDto {
+  final String id;
+  final String color;
+  final String brand;
+  final String model;
+  final String nrRejestracyjny;
+  final VehicleType type;
+  final int sittingCapacity;
+  final String cargoDimensions;
+  final String maxLoad;
+
+  VehicleDto({
+    required this.id,
+    required this.color,
+    required this.brand,
+    required this.model,
+    required this.nrRejestracyjny,
+    required this.type,
+    required this.sittingCapacity,
+    required this.cargoDimensions,
+    required this.maxLoad,
+  });
+
+  factory VehicleDto.fromJson(Map<String, dynamic> json) {
+    return VehicleDto(
+      id: json['id'] as String? ?? '',
+      color: json['color'] as String? ?? '',
+      brand: json['brand'] as String? ?? 'Unknown',
+      model: json['model'] as String? ?? 'Unknown',
+      nrRejestracyjny: json['nrRejestracyjny'] as String? ?? '',
+      type: _stringToVehicleType(json['type'] as String?),
+      sittingCapacity: json['sittingCapacity'] is String
+          ? int.tryParse(json['sittingCapacity']) ?? 0
+          : (json['sittingCapacity'] as int? ?? 0),
+      cargoDimensions: json['cargoDimensions'] as String? ?? '',
+      maxLoad: json['maxLoad'] as String? ?? '',
+    );
+  }
+
+  factory VehicleDto.fromFirestore(DocumentSnapshot doc) {
+    final data = (doc.data() as Map<String, dynamic>? ?? {})..putIfAbsent('id', () => doc.id);
+    return VehicleDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'color': color,
+      'brand': brand,
+      'model': model,
+      'nrRejestracyjny': nrRejestracyjny,
+      'type': _vehicleTypeToString(type),
+      'sittingCapacity': sittingCapacity,
+      'cargoDimensions': cargoDimensions,
+      'maxLoad': maxLoad,
+    };
+  }
+
+  Vehicle toDomain() {
+    return Vehicle(
+      id: id,
+      color: color,
+      brand: brand,
+      model: model,
+      nrRejestracyjny: nrRejestracyjny,
+      type: type,
+      sittingCapacity: sittingCapacity,
+      cargoDimensions: cargoDimensions,
+      maxLoad: maxLoad,
+    );
+  }
+
+  factory VehicleDto.fromDomain(Vehicle vehicle) {
+    return VehicleDto(
+      id: vehicle.id,
+      color: vehicle.color,
+      brand: vehicle.brand,
+      model: vehicle.model,
+      nrRejestracyjny: vehicle.nrRejestracyjny,
+      type: vehicle.type,
+      sittingCapacity: vehicle.sittingCapacity,
+      cargoDimensions: vehicle.cargoDimensions,
+      maxLoad: vehicle.maxLoad,
+    );
+  }
+}
+
+VehicleType _stringToVehicleType(String? value) {
+  switch (value) {
+    case 'osobowka':
+      return VehicleType.osobowka;
+    case 'dostawczy':
+      return VehicleType.dostawczy;
+    default:
+      return VehicleType.osobowka;
+  }
+}
+
+String _vehicleTypeToString(VehicleType type) {
+  switch (type) {
+    case VehicleType.osobowka:
+      return 'osobowka';
+    case VehicleType.dostawczy:
+      return 'dostawczy';
+  }
+}

--- a/data/services/app_user_firebase_service.dart
+++ b/data/services/app_user_firebase_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/models/app_user.dart';
 import '../../domain/services/i_app_user_service.dart';
+import '../dto/app_user_dto.dart';
 
 class AppUserFirebaseService implements IAppUserService {
   final FirebaseFirestore _firestore;
@@ -8,13 +9,14 @@ class AppUserFirebaseService implements IAppUserService {
   AppUserFirebaseService(this._firestore);
 
   Future<void> upsertAppUser(AppUser user) async {
-    await _firestore.collection('users').doc(user.id).set(user.toJson());
+    final dto = AppUserDto.fromDomain(user);
+    await _firestore.collection('users').doc(user.id).set(dto.toJson());
   }
 
   Stream<AppUser?> getAppUserStream(String uid) {
     return _firestore.collection('users').doc(uid).snapshots().map((doc) {
       if (!doc.exists) return null;
-      return AppUser.fromJson(doc.data() as Map<String, dynamic>);
+      return AppUserDto.fromFirestore(doc).toDomain();
     });
   }
 }

--- a/data/services/employee_firebase_service.dart
+++ b/data/services/employee_firebase_service.dart
@@ -1,35 +1,30 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-
-<<<<<<< HEAD:data/services/empleyee_firebase_service.dart
-import '../../domain/models/emplyee.dart';
-import '../../domain/services/i_employee_service.dart';
-=======
 import '../../domain/models/employee.dart';
->>>>>>> f31b4e4f21ac90b05b7d56404f5fa23e7a182d8e:data/services/employee_firebase_service.dart
+import '../../domain/services/i_employee_service.dart';
+import '../dto/employee_dto.dart';
 
 class EmployeeFirebaseService implements IEmployeeService {
   final FirebaseFirestore _firestore;
 
   EmployeeFirebaseService(this._firestore);
 
-  /// Strumień pracowników z kolekcji 'workers'
+  @override
   Stream<List<Employee>> getEmployeesStream() {
     return _firestore.collection('workers').snapshots().map((querySnapshot) {
       return querySnapshot.docs.map((doc) {
-        final data = doc.data();
-        data['uid'] = doc.id;
-        return Employee.fromJson(data);
+        return EmployeeDto.fromFirestore(doc).toDomain();
       }).toList();
     });
   }
 
-  /// Zapisuje lub nadpisuje pracownika
+  @override
   Future<void> upsertEmployee(Employee employee) async {
+    final dto = EmployeeDto.fromDomain(employee);
     if (employee.uid.isEmpty) {
-      final docRef = await _firestore.collection('workers').add(employee.toJson());
+      final docRef = await _firestore.collection('workers').add(dto.toJson());
       await docRef.update({'uid': docRef.id});
     } else {
-      await _firestore.collection('workers').doc(employee.uid).set(employee.toJson());
+      await _firestore.collection('workers').doc(employee.uid).set(dto.toJson());
     }
   }
 }

--- a/data/services/vehicle_firebase_service.dart
+++ b/data/services/vehicle_firebase_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/models/vehicle.dart';
 import '../../domain/services/i_vehicle_service.dart';
+import '../dto/vehicle_dto.dart';
 
 class VehicleFirebaseService implements IVehicleService {
   final FirebaseFirestore _firestore;
@@ -10,17 +11,18 @@ class VehicleFirebaseService implements IVehicleService {
   Stream<List<Vehicle>> getVehiclesStream() {
     return _firestore.collection('vehicles').snapshots().map((querySnapshot) {
       return querySnapshot.docs.map((doc) {
-        return Vehicle.fromJson(doc.data());
+        return VehicleDto.fromFirestore(doc).toDomain();
       }).toList();
     });
   }
 
   Future<void> upsertVehicle(Vehicle vehicle) async {
+    final dto = VehicleDto.fromDomain(vehicle);
     if (vehicle.id.isEmpty) {
-      final docRef = await _firestore.collection('vehicles').add(vehicle.toJson());
+      final docRef = await _firestore.collection('vehicles').add(dto.toJson());
       await docRef.update({'id': docRef.id});
     } else {
-      await _firestore.collection('vehicles').doc(vehicle.id).set(vehicle.toJson());
+      await _firestore.collection('vehicles').doc(vehicle.id).set(dto.toJson());
     }
   }
 }

--- a/domain/models/app_user.dart
+++ b/domain/models/app_user.dart
@@ -1,6 +1,3 @@
-import 'package:json_annotation/json_annotation.dart';
-
-part 'app_user.g.dart';
 
 enum UserRole {
   admin,
@@ -104,13 +101,11 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
 }
 
 /// Model użytkownika w Firestore (kolekcja "users")
-@JsonSerializable()
 class AppUser {
   final String id;
   final String email;
   final String fullName;
   final String employeeId;
-  @JsonKey(unknownEnumValue: UserRole.user)
   final UserRole role;
   final Map<String, bool> permissionsOverride;
 
@@ -164,7 +159,4 @@ class AppUser {
     return defaults;
   }
 
-  factory AppUser.fromJson(Map<String, dynamic> json) => _$AppUserFromJson(json);
-
-  Map<String, dynamic> toJson() => _$AppUserToJson(this);
 }

--- a/domain/models/employee.dart
+++ b/domain/models/employee.dart
@@ -9,26 +9,6 @@ class Employee {
     required this.fullName,
   });
 
-  Map<String, dynamic> toJson() {
-    return {
-      'uid': uid,
-      'role': role,
-      'fullName': fullName,
-    };
-  }
-
-  factory Employee.fromJson(Map<String, dynamic> json) {
-    String getValue(String key, {String defaultValue = ''}) {
-      final value = json[key];
-      return value?.toString() ?? defaultValue;
-    }
-
-    return Employee(
-      uid: getValue('uid'),
-      role: getValue('role', defaultValue: 'worker'),
-      fullName: getValue('fullName', defaultValue: 'Anonimowy Pracownik'),
-    );
-  }
 
   String get surname {
     final parts = fullName.split(' ');

--- a/domain/models/vehicle.dart
+++ b/domain/models/vehicle.dart
@@ -1,10 +1,5 @@
-import 'package:json_annotation/json_annotation.dart';
-
-part 'vehicle.g.dart';
 
 enum VehicleType { osobowka, dostawczy }
-
-@JsonSerializable()
 class Vehicle {
   final String id;
   final String color;
@@ -28,7 +23,4 @@ class Vehicle {
     required this.maxLoad,
   });
 
-  factory Vehicle.fromJson(Map<String, dynamic> json) => _$VehicleFromJson(json);
-
-  Map<String, dynamic> toJson() => _$VehicleToJson(this);
 }


### PR DESCRIPTION
## Summary
- decouple serialization from domain models
- add dedicated DTOs for `AppUser`, `Employee`, and `Vehicle`
- update Firebase services to use DTOs

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865887f59448333b7a21e92911b4e6f