### PR TITLE
Fix EmployeeFirebaseService overrides

### DIFF
--- a/data/repositories/employee_repository.dart
+++ b/data/repositories/employee_repository.dart
@@ -1,11 +1,6 @@
 
-<<<<<<< HEAD:data/repositories/emplyee_repository.dart
-import '../../domain/models/emplyee.dart';
-import '../../domain/services/i_employee_service.dart';
-=======
 import '../../domain/models/employee.dart';
-import '../services/employee_firebase_service.dart';
->>>>>>> f31b4e4f21ac90b05b7d56404f5fa23e7a182d8e:data/repositories/employee_repository.dart
+import '../../domain/services/i_employee_service.dart';
 
 class EmployeeRepository {
   final IEmployeeService _service;

--- a/domain/services/i_employee_service.dart
+++ b/domain/services/i_employee_service.dart
@@ -1,4 +1,4 @@
-import '../models/emplyee.dart';
+import '../models/employee.dart';
 
 abstract class IEmployeeService {
   Stream<List<Employee>> getEmployeesStream();

--- a/feature/grafik/cubit/grafik_state.dart
+++ b/feature/grafik/cubit/grafik_state.dart
@@ -1,12 +1,8 @@
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/domain/models/vehicle.dart';
-<<<<<<< HEAD
-import 'package:kabast/domain/models/emplyee.dart';
-import 'states/week_grafik_data.dart';
-=======
 import 'package:kabast/domain/models/employee.dart';
->>>>>>> f31b4e4f21ac90b05b7d56404f5fa23e7a182d8e
+import 'states/week_grafik_data.dart';
 
 class GrafikState {
   final List<TaskElement> tasks;


### PR DESCRIPTION
## Summary
- fix the path in `IEmployeeService` to import `employee.dart`
- clean up merge leftovers in `EmployeeRepository`
- resolve conflict markers in `GrafikState`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf74513483339ff6980aa2e122b7