### PR TITLE
Refactor GrafikCubit provider

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:get_it/get_it.dart';
 import 'domain/models/grafik/grafik_element.dart';
 import 'feature/auth/screen/login_screen.dart';
 import 'feature/extra_options/extra_options_screen.dart';
-import 'feature/grafik/cubit/grafik_cubit.dart';
 import 'feature/grafik/form/grafik_element_form_screen.dart';
 import 'feature/grafik/grafik_wrapper.dart';
 import 'feature/grafik/widget/week/week_grafik_view.dart';
@@ -16,17 +13,11 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const LoginScreen());
       case '/grafik':
         return MaterialPageRoute(
-          builder: (_) => BlocProvider(
-            create: (_) => GetIt.instance<GrafikCubit>(),
-            child: const GrafikWrapper(),
-          ),
+          builder: (_) => const GrafikWrapper(),
         );
       case '/weekGrafik':
         return MaterialPageRoute(
-          builder: (_) => BlocProvider(
-            create: (_) => GetIt.instance<GrafikCubit>(),
-            child: const WeekGrafikView(),
-          ),
+          builder: (_) => const WeekGrafikView(),
         );
       case '/extras':
         return MaterialPageRoute(builder: (_) => const ExtraOptionsScreen());

--- a/main.dart
+++ b/main.dart
@@ -7,6 +7,7 @@ import 'feature/auth/wrapeer/auth_wrapper.dart';
 import 'firebase_options.dart';
 import 'injection.dart';
 import 'feature/auth/auth_cubit.dart';
+import 'feature/grafik/cubit/grafik_cubit.dart';
 import 'app_router.dart';
 import 'theme/theme.dart';
 
@@ -26,8 +27,15 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<AuthCubit>(
-      create: (_) => GetIt.instance<AuthCubit>(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthCubit>(
+          create: (_) => GetIt.instance<AuthCubit>(),
+        ),
+        BlocProvider<GrafikCubit>(
+          create: (_) => GetIt.instance<GrafikCubit>(),
+        ),
+      ],
       child: AuthWrapper(
         navigatorKey: navigatorKey,
         child: MaterialApp(


### PR DESCRIPTION
## Summary
- provide GrafikCubit alongside AuthCubit at the top level
- remove inline BlocProviders from `/grafik` and `/weekGrafik` routes
- clean up unused imports

## Testing
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6866c6f6350483338bd13ad54be7f218