### PR TITLE
Remove unused registry import

### DIFF
--- a/domain/models/grafik/grafik_element.dart
+++ b/domain/models/grafik/grafik_element.dart
@@ -1,5 +1,3 @@
-import 'grafik_element_registry.dart';
-
 abstract class GrafikElement {
   final String id;
   final DateTime startDateTime;


### PR DESCRIPTION
## Summary
- remove unused import from `GrafikElement`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d68cbfe483339c3f54ad93b45dfe