### PR TITLE
Refactor grafik form cubit

### DIFF
--- a/feature/grafik/form/adapter/grafik_element_form_adapter.dart
+++ b/feature/grafik/form/adapter/grafik_element_form_adapter.dart
@@ -1,0 +1,67 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../../data/dto/grafik/grafik_element_dto.dart';
+import '../../form/grafik_element_registry.dart';
+import '../../../../domain/models/grafik/grafik_element.dart';
+
+class GrafikElementFormAdapter {
+  GrafikElement toDomainFromDto(GrafikElementDto dto) => dto.toDomain();
+
+  GrafikElementDto toDtoFromDomain(GrafikElement element) =>
+      GrafikElementDto.fromDomain(element);
+
+  GrafikElement changeType(GrafikElement oldElement, String newType) {
+    final newElement =
+        GrafikElementRegistry.createDefaultElementForType(newType);
+    final newJson = GrafikElementDto.fromDomain(newElement).toJson();
+    final oldJson = GrafikElementDto.fromDomain(oldElement).toJson();
+
+    newJson['id'] = oldJson['id'];
+    newJson['startDateTime'] = oldJson['startDateTime'];
+    newJson['endDateTime'] = oldJson['endDateTime'];
+    newJson['additionalInfo'] = oldJson['additionalInfo'];
+
+    return GrafikElementDto.fromJson(newJson).toDomain();
+  }
+
+  GrafikElement updateField(
+    GrafikElement element,
+    String field,
+    dynamic value,
+  ) {
+    final map = GrafikElementDto.fromDomain(element).toJson();
+    if (field == 'startDateTime' || field == 'endDateTime') {
+      if (value is DateTime) {
+        map[field] = Timestamp.fromDate(value);
+      }
+    } else {
+      map[field] = value;
+    }
+
+    return GrafikElementDto.fromJson(map).toDomain();
+  }
+
+  GrafikElement copyWithOverrides(
+    GrafikElement element,
+    Map<String, dynamic> overrides,
+  ) {
+    final map = GrafikElementDto.fromDomain(element).toJson();
+    overrides.forEach((key, val) {
+      map[key] = val;
+    });
+    return GrafikElementDto.fromJson(map).toDomain();
+  }
+
+  GrafikElement fillMeta(GrafikElement element, String userId) {
+    final needUser = (element.addedByUserId).isEmpty;
+    final needTs = element.addedTimestamp.isBefore(DateTime(1970));
+
+    if (!needUser && !needTs) return element;
+
+    final json = GrafikElementDto.fromDomain(element).toJson();
+    if (needUser) json['addedByUserId'] = userId;
+    if (needTs) json['addedTimestamp'] = Timestamp.fromDate(DateTime.now());
+
+    return GrafikElementDto.fromJson(json).toDomain();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `GrafikElementFormAdapter` to map DTOs to domain and back
- rewrite `GrafikElementFormCubit` to use the adapter
- remove DTO/Timestamp logic from the cubit

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68677cc06e30833380daf0829732cb39