### PR TITLE
Refactor task ID generation

### DIFF
--- a/data/repositories/grafik_element_repository.dart
+++ b/data/repositories/grafik_element_repository.dart
@@ -19,6 +19,8 @@ class GrafikElementRepository {
     );
   }
 
+  String generateNewTaskId() => _service.generateNewTaskId();
+
   // ───────── pozostałe metody bez zmian ─────────
 
   Future<void> saveGrafikElement(GrafikElement element) =>

--- a/data/services/grafik_element_firebase_service.dart
+++ b/data/services/grafik_element_firebase_service.dart
@@ -10,6 +10,11 @@ class GrafikElementFirebaseService implements IGrafikElementService {
 
   GrafikElementFirebaseService(this._firestore);
 
+  @override
+  String generateNewTaskId() {
+    return _firestore.collection('grafik_elements').doc().id;
+  }
+
   // ───────────────────────────────────────────────────────────
   //  1.  Dotychczasowe zapytanie zakresem                 ════
   // ───────────────────────────────────────────────────────────

--- a/domain/services/i_grafik_element_service.dart
+++ b/domain/services/i_grafik_element_service.dart
@@ -16,6 +16,9 @@ abstract class IGrafikElementService {
     List<String>? types,
   });
 
+  /// Generate a new unique ID for creating task elements.
+  String generateNewTaskId();
+
   Future<void> upsertGrafikElement(GrafikElement element);
 
   Future<void> updateGrafikElementField(String id, Map<String, dynamic> data);

--- a/feature/grafik/cubit/form/grafik_element_form_cubit.dart
+++ b/feature/grafik/cubit/form/grafik_element_form_cubit.dart
@@ -1,6 +1,5 @@
 
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../data/repositories/grafik_element_repository.dart';
@@ -129,10 +128,7 @@ class GrafikElementFormCubit extends Cubit<GrafikElementFormState> {
 
     // Jeśli to nowe zadanie – generujemy ID (tylko TaskElement)
     if (element is TaskElement && element.id.isEmpty) {
-      final newId = FirebaseFirestore.instance
-          .collection('grafikElements')
-          .doc()
-          .id;
+      final newId = grafikService.generateNewTaskId();
       element = element.copyWithId(newId);
     }
 


### PR DESCRIPTION
## Summary
- add `generateNewTaskId` to `IGrafikElementService`
- implement `generateNewTaskId` in `GrafikElementFirebaseService`
- expose `generateNewTaskId` via `GrafikElementRepository`
- use repository to generate IDs in `GrafikElementFormCubit`
- remove direct Firestore import from cubit

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a1c1e85c8333a7a1c6b7fe16bb1a