### PR TITLE
Refactor GrafikElementFormAdapter to use DateTime

### DIFF
--- a/data/dto/grafik/delivery_planning_element_dto.dart
+++ b/data/dto/grafik/delivery_planning_element_dto.dart
@@ -26,15 +26,21 @@ class DeliveryPlanningElementDto extends GrafikElementDto {
         'DeliveryPlanningCategory.Inne';
     return DeliveryPlanningElementDto(
       id: json['id'] as String? ?? '',
-      startDateTime: (json['startDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
-      endDateTime: (json['endDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
+      startDateTime: GrafikElementDto.parseDateTime(
+        json['startDateTime'],
+        DateTime.now(),
+      ),
+      endDateTime: GrafikElementDto.parseDateTime(
+        json['endDateTime'],
+        DateTime.now(),
+      ),
       type: 'DeliveryPlanningElement',
       additionalInfo: json['additionalInfo'] as String? ?? '',
       addedByUserId: json['addedByUserId'] as String? ?? '',
-      addedTimestamp:
-          (json['addedTimestamp'] as Timestamp?)?.toDate() ?? DateTime(1960, 2, 9),
+      addedTimestamp: GrafikElementDto.parseDateTime(
+        json['addedTimestamp'],
+        DateTime(1960, 2, 9),
+      ),
       closed: json['closed'] as bool? ?? false,
       orderId: json['orderId'] as String? ?? '',
       category: DeliveryPlanningCategory.values.firstWhere(

--- a/data/dto/grafik/grafik_element_dto.dart
+++ b/data/dto/grafik/grafik_element_dto.dart
@@ -8,6 +8,17 @@ import '../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../domain/models/grafik/enums.dart';
 
 abstract class GrafikElementDto {
+  static DateTime parseDateTime(dynamic value, DateTime fallback) {
+    if (value is Timestamp) return value.toDate();
+    if (value is DateTime) return value;
+    if (value is int) {
+      return DateTime.fromMillisecondsSinceEpoch(value);
+    }
+    if (value is String) {
+      return DateTime.tryParse(value) ?? fallback;
+    }
+    return fallback;
+  }
   final String id;
   final DateTime startDateTime;
   final DateTime endDateTime;

--- a/data/dto/grafik/task_element_dto.dart
+++ b/data/dto/grafik/task_element_dto.dart
@@ -30,15 +30,21 @@ class TaskElementDto extends GrafikElementDto {
   factory TaskElementDto.fromJson(Map<String, dynamic> json) {
     return TaskElementDto(
       id: json['id'] as String? ?? '',
-      startDateTime: (json['startDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
-      endDateTime: (json['endDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
+      startDateTime: GrafikElementDto.parseDateTime(
+        json['startDateTime'],
+        DateTime.now(),
+      ),
+      endDateTime: GrafikElementDto.parseDateTime(
+        json['endDateTime'],
+        DateTime.now(),
+      ),
       type: 'TaskElement',
       additionalInfo: json['additionalInfo'] as String? ?? '',
       addedByUserId: json['addedByUserId'] as String? ?? '',
-      addedTimestamp:
-          (json['addedTimestamp'] as Timestamp?)?.toDate() ?? DateTime(1960, 2, 9),
+      addedTimestamp: GrafikElementDto.parseDateTime(
+        json['addedTimestamp'],
+        DateTime(1960, 2, 9),
+      ),
       closed: json['closed'] as bool? ?? false,
       workerIds: (json['workerIds'] as List?)?.cast<String>() ?? <String>[],
       orderId: json['orderId'] as String? ?? '',

--- a/data/dto/grafik/task_planning_element_dto.dart
+++ b/data/dto/grafik/task_planning_element_dto.dart
@@ -36,15 +36,21 @@ class TaskPlanningElementDto extends GrafikElementDto {
   factory TaskPlanningElementDto.fromJson(Map<String, dynamic> json) {
     return TaskPlanningElementDto(
       id: json['id'] as String? ?? '',
-      startDateTime: (json['startDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
-      endDateTime: (json['endDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
+      startDateTime: GrafikElementDto.parseDateTime(
+        json['startDateTime'],
+        DateTime.now(),
+      ),
+      endDateTime: GrafikElementDto.parseDateTime(
+        json['endDateTime'],
+        DateTime.now(),
+      ),
       type: 'TaskPlanningElement',
       additionalInfo: json['additionalInfo'] as String? ?? '',
       addedByUserId: json['addedByUserId'] as String? ?? '',
-      addedTimestamp:
-          (json['addedTimestamp'] as Timestamp?)?.toDate() ?? DateTime(1960, 2, 9),
+      addedTimestamp: GrafikElementDto.parseDateTime(
+        json['addedTimestamp'],
+        DateTime(1960, 2, 9),
+      ),
       closed: json['closed'] as bool? ?? false,
       workerCount: json['workerCount'] as int? ?? 1,
       orderId: json['orderId'] as String? ?? '',

--- a/data/dto/grafik/time_issue_element_dto.dart
+++ b/data/dto/grafik/time_issue_element_dto.dart
@@ -36,15 +36,21 @@ class TimeIssueElementDto extends GrafikElementDto {
   factory TimeIssueElementDto.fromJson(Map<String, dynamic> json) {
     return TimeIssueElementDto(
       id: json['id'] as String? ?? '',
-      startDateTime: (json['startDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
-      endDateTime: (json['endDateTime'] as Timestamp?)?.toDate() ??
-          DateTime.now(),
+      startDateTime: GrafikElementDto.parseDateTime(
+        json['startDateTime'],
+        DateTime.now(),
+      ),
+      endDateTime: GrafikElementDto.parseDateTime(
+        json['endDateTime'],
+        DateTime.now(),
+      ),
       type: 'TimeIssueElement',
       additionalInfo: json['additionalInfo'] as String? ?? '',
       addedByUserId: json['addedByUserId'] as String? ?? '',
-      addedTimestamp:
-          (json['addedTimestamp'] as Timestamp?)?.toDate() ?? DateTime(1960, 2, 9),
+      addedTimestamp: GrafikElementDto.parseDateTime(
+        json['addedTimestamp'],
+        DateTime(1960, 2, 9),
+      ),
       closed: json['closed'] as bool? ?? false,
       issueType: TimeIssueType.values.firstWhere(
         (e) => e.toString() ==

--- a/feature/grafik/form/adapter/grafik_element_form_adapter.dart
+++ b/feature/grafik/form/adapter/grafik_element_form_adapter.dart
@@ -1,5 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-
 import '../../../../data/dto/grafik/grafik_element_dto.dart';
 import '../../form/grafik_element_registry.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
@@ -32,7 +30,7 @@ class GrafikElementFormAdapter {
     final map = GrafikElementDto.fromDomain(element).toJson();
     if (field == 'startDateTime' || field == 'endDateTime') {
       if (value is DateTime) {
-        map[field] = Timestamp.fromDate(value);
+        map[field] = value;
       }
     } else {
       map[field] = value;
@@ -60,7 +58,7 @@ class GrafikElementFormAdapter {
 
     final json = GrafikElementDto.fromDomain(element).toJson();
     if (needUser) json['addedByUserId'] = userId;
-    if (needTs) json['addedTimestamp'] = Timestamp.fromDate(DateTime.now());
+    if (needTs) json['addedTimestamp'] = DateTime.now();
 
     return GrafikElementDto.fromJson(json).toDomain();
   }


### PR DESCRIPTION
## Summary
- refactor `GrafikElementFormAdapter` to handle only `DateTime` values
- centralize `Timestamp` conversions inside `GrafikElementDto`
- update DTO classes to use new helper method

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a1c236a083339113360041c12db3