### PR TITLE
Remove obsolete comments from picker widgets

### DIFF
--- a/feature/employee/employee_picker.dart
+++ b/feature/employee/employee_picker.dart
@@ -31,9 +31,6 @@ class _EmployeePickerState extends State<EmployeePicker> {
     _selectedEmployeeIds = widget.initialSelectedIds?.toSet() ?? {};
   }
 
-  // ───────────────────────────────────────────────────────────
-  // NEW – aktualizacja po zmianie initialSelectedIds
-  // ───────────────────────────────────────────────────────────
   @override
   void didUpdateWidget(covariant EmployeePicker oldWidget) {
     super.didUpdateWidget(oldWidget);

--- a/feature/vehicle/widget/vehicle_picker.dart
+++ b/feature/vehicle/widget/vehicle_picker.dart
@@ -29,9 +29,6 @@ class _VehiclePickerState extends State<VehiclePicker> {
     _selectedVehicleIds = widget.initialSelectedIds?.toSet() ?? {};
   }
 
-  // ───────────────────────────────────────────────────────────
-  // NEW – aktualizacja po zmianie initialSelectedIds
-  // ───────────────────────────────────────────────────────────
   @override
   void didUpdateWidget(covariant VehiclePicker oldWidget) {
     super.didUpdateWidget(oldWidget);


### PR DESCRIPTION
## Summary
- remove old update comments from `VehiclePicker` and `EmployeePicker`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867ba4bc72c833382a060732fe9ab5e