### PR TITLE
Fix AuthCubit stream management

### DIFF
--- a/feature/auth/auth_cubit.dart
+++ b/feature/auth/auth_cubit.dart
@@ -9,6 +9,7 @@ import '../../domain/models/app_user.dart';
 class AuthCubit extends Cubit<AuthState> {
   final FirebaseAuth _firebaseAuth;
   final AppUserRepository _userRepository;
+  late final StreamSubscription<User?> _authSub;
   StreamSubscription<AppUser?>? _userStreamSub;
 
   AppUser? _currentUser;
@@ -25,7 +26,7 @@ class AuthCubit extends Cubit<AuthState> {
 
   AuthCubit(this._firebaseAuth, this._userRepository) : super(AuthInitial()) {
     // Nasłuchujemy zmian stanu autoryzacji.
-    _firebaseAuth.authStateChanges().listen((user) async {
+    _authSub = _firebaseAuth.authStateChanges().listen((user) async {
       if (user == null) {
         await _userStreamSub?.cancel();
         emit(AuthUnauthenticated());
@@ -114,6 +115,7 @@ class AuthCubit extends Cubit<AuthState> {
 
   @override
   Future<void> close() async {
+    await _authSub.cancel();
     await _userStreamSub?.cancel();
     return super.close();
   }


### PR DESCRIPTION
## Summary
- manage subscription from `FirebaseAuth.instance.authStateChanges`
- close authStateChanges subscription when cubit closes

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b62e9f3dc8333b14ceaf27fb49986