### PR TITLE
Move worker conflict dialog to UI listener

### DIFF
--- a/feature/grafik/cubit/form/grafik_element_form_state.dart
+++ b/feature/grafik/cubit/form/grafik_element_form_state.dart
@@ -10,6 +10,7 @@ class GrafikElementFormEditing extends GrafikElementFormState {
   final bool isSuccess;
   final bool isFailure;
   final List<String> selectedWorkerIds;
+  final List<String> conflictWorkerIds;
 
   GrafikElementFormEditing({
     required this.element,
@@ -17,6 +18,7 @@ class GrafikElementFormEditing extends GrafikElementFormState {
     this.isSuccess = false,
     this.isFailure = false,
     this.selectedWorkerIds = const [],
+    this.conflictWorkerIds = const [],
   });
 
   GrafikElementFormEditing copyWith({
@@ -25,6 +27,7 @@ class GrafikElementFormEditing extends GrafikElementFormState {
     bool? isSuccess,
     bool? isFailure,
     List<String>? selectedWorkerIds,
+    List<String>? conflictWorkerIds,
   }) {
     return GrafikElementFormEditing(
       element: element ?? this.element,
@@ -32,6 +35,7 @@ class GrafikElementFormEditing extends GrafikElementFormState {
       isSuccess: isSuccess ?? this.isSuccess,
       isFailure: isFailure ?? this.isFailure,
       selectedWorkerIds: selectedWorkerIds ?? this.selectedWorkerIds,
+      conflictWorkerIds: conflictWorkerIds ?? this.conflictWorkerIds,
     );
   }
 }

--- a/feature/grafik/form/grafik_element_form_screen.dart
+++ b/feature/grafik/form/grafik_element_form_screen.dart
@@ -10,6 +10,7 @@ import '../../../shared/form/custom_button.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
 import '../../../data/repositories/grafik_element_repository.dart';
+import '../widget/dialog/worker_conflict_popup.dart';
 
 class GrafikElementFormScreen extends StatelessWidget {
   final GrafikElement? existingElement;
@@ -28,6 +29,20 @@ class GrafikElementFormScreen extends StatelessWidget {
             WidgetsBinding.instance.addPostFrameCallback((_) {
               if (Navigator.of(context).canPop()) {
                 Navigator.of(context).pop(true);
+              }
+            });
+          }
+
+          if (state is GrafikElementFormEditing && state.conflictWorkerIds.isNotEmpty) {
+            WidgetsBinding.instance.addPostFrameCallback((_) async {
+              final decision = await showWorkerConflictDialog(
+                context,
+                state.conflictWorkerIds,
+              );
+              if (decision == true) {
+                context
+                    .read<GrafikElementFormCubit>()
+                    .saveElement(resolveConflict: true);
               }
             });
           }


### PR DESCRIPTION
## Summary
- signal worker conflicts via state in `GrafikElementFormCubit`
- present `WorkerConflictPopup` from `GrafikElementFormScreen`
- extend form state with `conflictWorkerIds`
- update save routine to handle confirmation flag

## Testing
- `dart` and `flutter` were unavailable so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_686b76249c0c8333af45dc2048bcb932