### PR TITLE
Introduce WeekGrafikDataService

### DIFF
--- a/data/services/week_grafik_data_service.dart
+++ b/data/services/week_grafik_data_service.dart
@@ -1,0 +1,52 @@
+import 'package:rxdart/rxdart.dart';
+
+import '../../domain/models/employee.dart';
+import '../../domain/models/grafik/grafik_element.dart';
+import '../../domain/models/grafik/impl/delivery_planning_element.dart';
+import '../../domain/models/grafik/impl/task_element.dart';
+import '../../domain/models/grafik/impl/task_planning_element.dart';
+import '../../domain/models/grafik/impl/time_issue_element.dart';
+import '../repositories/grafik_element_repository.dart';
+import '../repositories/employee_repository.dart';
+import '../../feature/grafik/cubit/states/week_grafik_data.dart';
+
+class WeekGrafikDataService {
+  final GrafikElementRepository _grafikRepo;
+  final EmployeeRepository _employeeRepo;
+
+  WeekGrafikDataService(this._grafikRepo, this._employeeRepo);
+
+  Stream<WeekGrafikData> loadWeek(DateTime monday) {
+    final friday = monday.add(const Duration(
+        days: 4, hours: 23, minutes: 59, seconds: 59, milliseconds: 999));
+
+    final grafikStream = _grafikRepo.getElementsWithinRange(
+      start: monday,
+      end: friday,
+      types: [
+        'TaskElement',
+        'TimeIssueElement',
+        'TaskPlanningElement',
+        'DeliveryPlanningElement',
+      ],
+    );
+
+    final employeeStream = _employeeRepo.getEmployees();
+
+    return Rx.combineLatest2<List<GrafikElement>, List<Employee>, WeekGrafikData>(
+        grafikStream, employeeStream, (elements, employees) {
+      final taskElements = elements.whereType<TaskElement>().toList();
+      final timeIssues = elements.whereType<TimeIssueElement>().toList();
+      final taskPlannings = elements.whereType<TaskPlanningElement>().toList();
+      final deliveryPlannings =
+          elements.whereType<DeliveryPlanningElement>().toList();
+
+      return WeekGrafikData(
+        taskElements: taskElements,
+        timeIssues: timeIssues,
+        taskPlannings: taskPlannings,
+        deliveryPlannings: deliveryPlannings,
+      );
+    });
+  }
+}

--- a/injection.dart
+++ b/injection.dart
@@ -17,6 +17,7 @@ import 'package:kabast/feature/date/date_cubit.dart';
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
+import 'package:kabast/data/services/week_grafik_data_service.dart';
 
 
 final getIt = GetIt.instance;
@@ -55,6 +56,13 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<GrafikElementRepository>(
     () => GrafikElementRepository(getIt<IGrafikElementService>()),
+  );
+
+  getIt.registerLazySingleton<WeekGrafikDataService>(
+    () => WeekGrafikDataService(
+      getIt<GrafikElementRepository>(),
+      getIt<EmployeeRepository>(),
+    ),
   );
 
   //CUBIT


### PR DESCRIPTION
## Summary
- create `WeekGrafikDataService` to load week data
- register the service in `injection.dart`

## Testing
- `dart` and `flutter` commands are unavailable in the environment

------
https://chatgpt.com/codex/tasks/task_e_686b8982353c83339a56c09b7d474e20