### PR TITLE
Add VehicleWatcher service and integrate with GrafikCubit

### DIFF
--- a/data/services/vehicle_watcher.dart
+++ b/data/services/vehicle_watcher.dart
@@ -1,0 +1,12 @@
+import '../repositories/vehicle_repository.dart';
+import '../../domain/models/vehicle.dart';
+
+class VehicleWatcher {
+  final VehicleRepository _vehicleRepository;
+
+  VehicleWatcher(this._vehicleRepository);
+
+  Stream<List<Vehicle>> watchVehicles() {
+    return _vehicleRepository.getVehicles();
+  }
+}

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -4,7 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import '../../../data/repositories/employee_repository.dart';
 import '../../../data/repositories/grafik_element_repository.dart';
-import '../../../data/repositories/vehicle_repository.dart';
+import '../../../data/services/vehicle_watcher.dart';
 import '../../date/date_cubit.dart';
 import '../../../domain/models/employee.dart';
 import '../../../domain/models/grafik/grafik_element.dart';
@@ -23,7 +23,7 @@ extension DateOnlyCompare on DateTime {
 
 class GrafikCubit extends Cubit<GrafikState> {
   final GrafikElementRepository _grafikRepo;
-  final VehicleRepository _vehicleRepo;
+  final VehicleWatcher _vehicleWatcher;
   final EmployeeRepository _employeeRepo;
   final DateCubit _dateCubit;
 
@@ -34,7 +34,7 @@ class GrafikCubit extends Cubit<GrafikState> {
 
   GrafikCubit(
       this._grafikRepo,
-      this._vehicleRepo,
+      this._vehicleWatcher,
       this._employeeRepo,
       this._dateCubit,
       ) : super(GrafikState.initial()) {
@@ -49,7 +49,7 @@ class GrafikCubit extends Cubit<GrafikState> {
 
 
   void _subscribeVehicles() {
-    _vehicleSub = _vehicleRepo.getVehicles().listen(
+    _vehicleSub = _vehicleWatcher.watchVehicles().listen(
           (vehicles) {
         if (!isClosed) {
           emit(state.copyWith(vehicles: vehicles));

--- a/injection.dart
+++ b/injection.dart
@@ -6,6 +6,7 @@ import 'package:kabast/data/services/app_user_firebase_service.dart';
 
 import 'package:kabast/data/repositories/employee_repository.dart';
 import 'package:kabast/data/repositories/vehicle_repository.dart';
+import 'package:kabast/data/services/vehicle_watcher.dart';
 import 'package:kabast/data/services/employee_firebase_service.dart';
 import 'package:kabast/data/services/vehicle_firebase_service.dart';
 import 'package:kabast/domain/services/i_app_user_service.dart';
@@ -55,6 +56,9 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<VehicleRepository>(
     () => VehicleRepository(getIt<IVehicleService>()),
   );
+  getIt.registerLazySingleton<VehicleWatcher>(
+    () => VehicleWatcher(getIt<VehicleRepository>()),
+  );
   getIt.registerLazySingleton<GrafikElementRepository>(
     () => GrafikElementRepository(getIt<IGrafikElementService>()),
   );
@@ -85,7 +89,7 @@ Future<void> setupLocator() async {
   getIt.registerFactory<GrafikCubit>(
     () => GrafikCubit(
       getIt<GrafikElementRepository>(),
-      getIt<VehicleRepository>(),
+      getIt<VehicleWatcher>(),
       getIt<EmployeeRepository>(),
       getIt<DateCubit>(),
     ),


### PR DESCRIPTION
## Summary
- add a `VehicleWatcher` service for streaming vehicles
- use `VehicleWatcher` in `GrafikCubit`
- register `VehicleWatcher` in dependency injection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b93060f188333bc000af672b72f64