### PR TITLE
Move GrafikElementFormAdapter

### DIFF
--- a/feature/grafik/form/grafik_element_form_adapter.dart
+++ b/feature/grafik/form/grafik_element_form_adapter.dart
@@ -1,6 +1,6 @@
-import '../dto/grafik/grafik_element_dto.dart';
-import '../../feature/grafik/form/grafik_element_registry.dart';
-import '../../domain/models/grafik/grafik_element.dart';
+import '../../../data/dto/grafik/grafik_element_dto.dart';
+import 'grafik_element_registry.dart';
+import '../../../domain/models/grafik/grafik_element.dart';
 
 class GrafikElementFormAdapter {
   GrafikElement toDomainFromDto(GrafikElementDto dto) => dto.toDomain();

--- a/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
@@ -1,4 +1,4 @@
-import '../../../data/adapters/grafik_element_form_adapter.dart';
+import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';

--- a/feature/grafik/form/strategy/task_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_element_strategy.dart
@@ -1,4 +1,4 @@
-import '../../../data/adapters/grafik_element_form_adapter.dart';
+import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';

--- a/feature/grafik/form/strategy/task_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_planning_element_strategy.dart
@@ -1,4 +1,4 @@
-import '../../../data/adapters/grafik_element_form_adapter.dart';
+import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';

--- a/feature/grafik/form/strategy/time_issue_element_strategy.dart
+++ b/feature/grafik/form/strategy/time_issue_element_strategy.dart
@@ -1,4 +1,4 @@
-import '../../../data/adapters/grafik_element_form_adapter.dart';
+import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';


### PR DESCRIPTION
## Summary
- move `GrafikElementFormAdapter` back to feature layer
- update strategy imports

## Testing
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3f7ccd5c8333a49a10dc7bb7c686