### PR TITLE
Move FirebaseAuth logic to new AuthFirebaseService

### DIFF
--- a/data/services/auth_firebase_service.dart
+++ b/data/services/auth_firebase_service.dart
@@ -1,0 +1,57 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import '../../domain/models/app_user.dart';
+import '../../domain/services/i_auth_service.dart';
+import '../repositories/app_user_repository.dart';
+
+class AuthFirebaseService implements IAuthService {
+  final FirebaseAuth _firebaseAuth;
+  final AppUserRepository _userRepository;
+
+  AuthFirebaseService(this._firebaseAuth, this._userRepository);
+
+  @override
+  Stream<AppUser?> authStateChanges() {
+    return _firebaseAuth.authStateChanges().asyncExpand((user) async* {
+      if (user == null) {
+        yield null;
+        return;
+      }
+      final existing = await _userRepository.getUserStream(user.uid).first;
+      if (existing == null) {
+        final newUser = AppUser.defaultUser(
+          id: user.uid,
+          email: user.email ?? '',
+        );
+        await _userRepository.saveUser(newUser);
+      }
+      yield* _userRepository.getUserStream(user.uid);
+    });
+  }
+
+  @override
+  Future<void> signUp(String email, String password) async {
+    final cred = await _firebaseAuth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    final user = cred.user;
+    if (user != null) {
+      final newUser = AppUser.defaultUser(
+        id: user.uid,
+        email: user.email ?? '',
+      );
+      await _userRepository.saveUser(newUser);
+    }
+  }
+
+  @override
+  Future<void> signIn(String email, String password) {
+    return _firebaseAuth.signInWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+  }
+
+  @override
+  Future<void> signOut() => _firebaseAuth.signOut();
+}

--- a/domain/services/i_auth_service.dart
+++ b/domain/services/i_auth_service.dart
@@ -1,0 +1,8 @@
+import '../models/app_user.dart';
+
+abstract class IAuthService {
+  Stream<AppUser?> authStateChanges();
+  Future<void> signUp(String email, String password);
+  Future<void> signIn(String email, String password);
+  Future<void> signOut();
+}

--- a/feature/auth/auth_cubit.dart
+++ b/feature/auth/auth_cubit.dart
@@ -1,16 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'auth_state.dart';
-import '../../data/repositories/app_user_repository.dart';
 import '../../domain/models/app_user.dart';
+import '../../domain/services/i_auth_service.dart';
 
 class AuthCubit extends Cubit<AuthState> {
-  final FirebaseAuth _firebaseAuth;
-  final AppUserRepository _userRepository;
-  late final StreamSubscription<User?> _authSub;
-  StreamSubscription<AppUser?>? _userStreamSub;
+  final IAuthService _authService;
+  late final StreamSubscription<AppUser?> _authSub;
 
   AppUser? _currentUser;
   AppUser? get currentUser => _currentUser;
@@ -24,32 +21,13 @@ class AuthCubit extends Cubit<AuthState> {
     _loginPassword = '';
   }
 
-  AuthCubit(this._firebaseAuth, this._userRepository) : super(AuthInitial()) {
-    // Nasłuchujemy zmian stanu autoryzacji.
-    _authSub = _firebaseAuth.authStateChanges().listen((user) async {
-      if (user == null) {
-        await _userStreamSub?.cancel();
-        emit(AuthUnauthenticated());
+  AuthCubit(this._authService) : super(AuthInitial()) {
+    _authSub = _authService.authStateChanges().listen((appUser) {
+      _currentUser = appUser;
+      if (appUser != null) {
+        emit(AuthAuthenticated());
       } else {
-        // Użytkownik zalogowany – pobieramy dane z Firestore i subskrybujemy dalsze zmiany.
-        final appUserFromStream = await _userRepository.getUserStream(user.uid).first;
-        if (appUserFromStream == null) {
-          // Zamiast ręcznie tworzyć obiekt, korzystamy z AppUser.defaultUser
-          final newUser = AppUser.defaultUser(
-            id: user.uid,
-            email: user.email ?? '',
-          );
-          await _userRepository.saveUser(newUser);
-        }
-        await _userStreamSub?.cancel();
-        _userStreamSub = _userRepository.getUserStream(user.uid).listen((appUser) {
-          _currentUser = appUser;
-          if (appUser != null) {
-            emit(AuthAuthenticated());
-          } else {
-            emit(AuthUnauthenticated());
-          }
-        });
+        emit(AuthUnauthenticated());
       }
     });
   }
@@ -66,22 +44,10 @@ class AuthCubit extends Cubit<AuthState> {
   Future<void> signUp() async {
     try {
       emit(AuthLoading());
-      final email = _loginEmail.trim();
-      final password = _loginPassword.trim();
-
-      final credential = await _firebaseAuth.createUserWithEmailAndPassword(
-        email: email,
-        password: password,
+      await _authService.signUp(
+        _loginEmail.trim(),
+        _loginPassword.trim(),
       );
-      final user = credential.user;
-      if (user != null) {
-        // Tworzymy nowego użytkownika z minimalnymi danymi (ID i email), reszta domyślna
-        final newUser = AppUser.defaultUser(
-          id: user.uid,
-          email: user.email ?? '',
-        );
-        await _userRepository.saveUser(newUser);
-      }
     } catch (e) {
       emit(AuthError(e.toString()));
     }
@@ -91,22 +57,20 @@ class AuthCubit extends Cubit<AuthState> {
   Future<void> signIn() async {
     try {
       emit(AuthLoading());
-      await _firebaseAuth.signInWithEmailAndPassword(
-        email: _loginEmail.trim(),
-        password: _loginPassword.trim(),
+      await _authService.signIn(
+        _loginEmail.trim(),
+        _loginPassword.trim(),
       );
-      _clearLoginFields(); // <--- czyścimy dopiero po sukcesie
+      _clearLoginFields();
     } catch (e) {
       emit(AuthError(e.toString()));
-      // Nie czyścimy pól w razie błędu
     }
   }
 
   Future<void> signOut() async {
     try {
       emit(AuthLoading());
-      await _userStreamSub?.cancel();
-      await _firebaseAuth.signOut();
+      await _authService.signOut();
       emit(AuthUnauthenticated());
     } catch (e) {
       emit(AuthError(e.toString()));
@@ -116,7 +80,6 @@ class AuthCubit extends Cubit<AuthState> {
   @override
   Future<void> close() async {
     await _authSub.cancel();
-    await _userStreamSub?.cancel();
     return super.close();
   }
 }

--- a/injection.dart
+++ b/injection.dart
@@ -3,6 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get_it/get_it.dart';
 import 'package:kabast/data/repositories/app_user_repository.dart';
 import 'package:kabast/data/services/app_user_firebase_service.dart';
+import 'package:kabast/data/services/auth_firebase_service.dart';
 
 import 'package:kabast/data/repositories/employee_repository.dart';
 import 'package:kabast/data/repositories/vehicle_repository.dart';
@@ -12,6 +13,7 @@ import 'package:kabast/data/services/vehicle_firebase_service.dart';
 import 'package:kabast/domain/services/i_app_user_service.dart';
 import 'package:kabast/domain/services/i_employee_service.dart';
 import 'package:kabast/domain/services/i_vehicle_service.dart';
+import 'package:kabast/domain/services/i_auth_service.dart';
 import 'package:kabast/feature/auth/auth_cubit.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
@@ -59,10 +61,16 @@ Future<void> setupLocator() async {
     () => GrafikElementRepository(getIt<IGrafikElementService>()),
   );
 
+  getIt.registerLazySingleton<IAuthService>(
+    () => AuthFirebaseService(
+      getIt<FirebaseAuth>(),
+      getIt<AppUserRepository>(),
+    ),
+  );
+
   //CUBIT
-  // Rejestracja AuthCUBIT jako factory – przekazujemy FirebaseAuth oraz AppUserRepository
   getIt.registerFactory<AuthCubit>(
-    () => AuthCubit(getIt<FirebaseAuth>(), getIt<AppUserRepository>()),
+    () => AuthCubit(getIt<IAuthService>()),
   );
 
   getIt.registerLazySingleton<DateCubit>(


### PR DESCRIPTION
## Summary
- create `IAuthService` interface exposing a Stream of `AppUser`
- implement `AuthFirebaseService` with `FirebaseAuth`
- refactor `AuthCubit` to rely only on `IAuthService`
- register new service and interface in `injection.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e40ded5c48333a4ecc3bf0b1428e9