### PR TITLE
Refactor cubits to use service interfaces

### DIFF
--- a/data/services/grafik_resolver.dart
+++ b/data/services/grafik_resolver.dart
@@ -1,12 +1,14 @@
-import 'package:kabast/data/repositories/grafik_element_repository.dart';
+import '../repositories/grafik_element_repository.dart';
+import '../../domain/services/i_grafik_resolver.dart';
 
-class GrafikResolver {
+class GrafikResolver implements IGrafikResolver {
   final GrafikElementRepository _repo;
 
   GrafikResolver(this._repo);
 
   /// Szuka najbliższego dnia z jakimkolwiek zadaniem (TaskElement/TimeIssueElement),
   /// zaczynając od `from` (inclusive).
+  @override
   Future<DateTime> nextDayWithGrafik(DateTime from) async {
     DateTime current = DateTime(from.year, from.month, from.day);
 

--- a/data/services/vehicle_watcher.dart
+++ b/data/services/vehicle_watcher.dart
@@ -1,11 +1,13 @@
 import '../repositories/vehicle_repository.dart';
 import '../../domain/models/vehicle.dart';
+import '../../domain/services/i_vehicle_watcher_service.dart';
 
-class VehicleWatcher {
+class VehicleWatcher implements IVehicleWatcherService {
   final VehicleRepository _vehicleRepository;
 
   VehicleWatcher(this._vehicleRepository);
 
+  @override
   Stream<List<Vehicle>> watchVehicles() {
     return _vehicleRepository.getVehicles();
   }

--- a/domain/services/i_grafik_resolver.dart
+++ b/domain/services/i_grafik_resolver.dart
@@ -1,0 +1,3 @@
+abstract class IGrafikResolver {
+  Future<DateTime> nextDayWithGrafik(DateTime from);
+}

--- a/domain/services/i_vehicle_watcher_service.dart
+++ b/domain/services/i_vehicle_watcher_service.dart
@@ -1,0 +1,5 @@
+import '../models/vehicle.dart';
+
+abstract class IVehicleWatcherService {
+  Stream<List<Vehicle>> watchVehicles();
+}

--- a/feature/date/date_cubit.dart
+++ b/feature/date/date_cubit.dart
@@ -1,18 +1,15 @@
 import 'dart:async';
 import 'package:bloc/bloc.dart';
 
-import '../../data/grafik_resolver.dart';
-import '../../data/repositories/grafik_element_repository.dart';
+import '../../domain/services/i_grafik_resolver.dart';
 
 import 'date_state.dart';
 
 class DateCubit extends Cubit<DateState> {
-  final GrafikElementRepository _grafikRepo;
-  late final GrafikResolver _grafikResolver;
+  final IGrafikResolver _grafikResolver;
   Timer? tickTimer;
 
-  DateCubit(this._grafikRepo) : super(DateState.initial()) {
-    _grafikResolver = GrafikResolver(_grafikRepo);
+  DateCubit(this._grafikResolver) : super(DateState.initial()) {
     _resolveInitialDayAndLoad();
     _scheduleUpdateAtGrafikChangeTime();
   }

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -4,7 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import '../../../data/repositories/employee_repository.dart';
 import '../../../data/repositories/grafik_element_repository.dart';
-import '../../../data/services/vehicle_watcher.dart';
+import '../../../domain/services/i_vehicle_watcher_service.dart';
 import '../../date/date_cubit.dart';
 import '../../../domain/models/employee.dart';
 import '../../../domain/models/grafik/grafik_element.dart';
@@ -23,7 +23,7 @@ extension DateOnlyCompare on DateTime {
 
 class GrafikCubit extends Cubit<GrafikState> {
   final GrafikElementRepository _grafikRepo;
-  final VehicleWatcher _vehicleWatcher;
+  final IVehicleWatcherService _vehicleWatcher;
   final EmployeeRepository _employeeRepo;
   final DateCubit _dateCubit;
 

--- a/injection.dart
+++ b/injection.dart
@@ -8,11 +8,14 @@ import 'package:kabast/data/services/auth_firebase_service.dart';
 import 'package:kabast/data/repositories/employee_repository.dart';
 import 'package:kabast/data/repositories/vehicle_repository.dart';
 import 'package:kabast/data/services/vehicle_watcher.dart';
+import 'package:kabast/data/services/grafik_resolver.dart';
 import 'package:kabast/data/services/employee_firebase_service.dart';
 import 'package:kabast/data/services/vehicle_firebase_service.dart';
 import 'package:kabast/domain/services/i_app_user_service.dart';
 import 'package:kabast/domain/services/i_employee_service.dart';
 import 'package:kabast/domain/services/i_vehicle_service.dart';
+import 'package:kabast/domain/services/i_vehicle_watcher_service.dart';
+import 'package:kabast/domain/services/i_grafik_resolver.dart';
 import 'package:kabast/domain/services/i_auth_service.dart';
 import 'package:kabast/feature/auth/auth_cubit.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
@@ -54,11 +57,14 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<VehicleRepository>(
     () => VehicleRepository(getIt<IVehicleService>()),
   );
-  getIt.registerLazySingleton<VehicleWatcher>(
+  getIt.registerLazySingleton<IVehicleWatcherService>(
     () => VehicleWatcher(getIt<VehicleRepository>()),
   );
   getIt.registerLazySingleton<GrafikElementRepository>(
     () => GrafikElementRepository(getIt<IGrafikElementService>()),
+  );
+  getIt.registerLazySingleton<IGrafikResolver>(
+    () => GrafikResolver(getIt<GrafikElementRepository>()),
   );
 
   getIt.registerLazySingleton<IAuthService>(
@@ -74,13 +80,13 @@ Future<void> setupLocator() async {
   );
 
   getIt.registerLazySingleton<DateCubit>(
-    () => DateCubit(getIt<GrafikElementRepository>()),
+    () => DateCubit(getIt<IGrafikResolver>()),
   );
 
   getIt.registerFactory<GrafikCubit>(
     () => GrafikCubit(
       getIt<GrafikElementRepository>(),
-      getIt<VehicleWatcher>(),
+      getIt<IVehicleWatcherService>(),
       getIt<EmployeeRepository>(),
       getIt<DateCubit>(),
     ),


### PR DESCRIPTION
## Summary
- add `IVehicleWatcherService` and `IGrafikResolver` interfaces
- implement them in data layer
- inject interfaces into `GrafikCubit` and `DateCubit`
- update dependency registration

## Testing
- `dart` was not available so no static analysis could be run

------
https://chatgpt.com/codex/tasks/task_e_686e44fafc4c833382cbb2f1647d5a87