### PR TITLE
Inject repository into form adapter

### DIFF
--- a/data/repositories/grafik_element_repository.dart
+++ b/data/repositories/grafik_element_repository.dart
@@ -1,6 +1,7 @@
 import '../../domain/models/grafik/enums.dart';
 import '../../domain/models/grafik/grafik_element.dart';
 import '../../domain/services/i_grafik_element_service.dart';
+import '../dto/grafik/grafik_element_dto.dart';
 
 class GrafikElementRepository {
   final IGrafikElementService _service;
@@ -20,6 +21,18 @@ class GrafikElementRepository {
   }
 
   String generateNewTaskId() => _service.generateNewTaskId();
+
+  // ────────────── DTO/JSON helpers ──────────────
+  GrafikElement fromDto(GrafikElementDto dto) => dto.toDomain();
+
+  GrafikElementDto toDto(GrafikElement element) =>
+      GrafikElementDto.fromDomain(element);
+
+  GrafikElement fromJson(Map<String, dynamic> json) =>
+      GrafikElementDto.fromJson(json).toDomain();
+
+  Map<String, dynamic> toJson(GrafikElement element) =>
+      GrafikElementDto.fromDomain(element).toJson();
 
   // ───────── pozostałe metody bez zmian ─────────
 

--- a/feature/grafik/form/grafik_element_form_adapter.dart
+++ b/feature/grafik/form/grafik_element_form_adapter.dart
@@ -1,25 +1,26 @@
-import '../../../data/dto/grafik/grafik_element_dto.dart';
 import 'grafik_element_registry.dart';
 import '../../../domain/models/grafik/grafik_element.dart';
+import '../../../data/repositories/grafik_element_repository.dart';
+import '../../../injection.dart';
 
 class GrafikElementFormAdapter {
-  GrafikElement toDomainFromDto(GrafikElementDto dto) => dto.toDomain();
+  final GrafikElementRepository _repo;
 
-  GrafikElementDto toDtoFromDomain(GrafikElement element) =>
-      GrafikElementDto.fromDomain(element);
+  GrafikElementFormAdapter({GrafikElementRepository? repo})
+      : _repo = repo ?? getIt<GrafikElementRepository>();
 
   GrafikElement changeType(GrafikElement oldElement, String newType) {
     final newElement =
         GrafikElementRegistry.createDefaultElementForType(newType);
-    final newJson = GrafikElementDto.fromDomain(newElement).toJson();
-    final oldJson = GrafikElementDto.fromDomain(oldElement).toJson();
+    final newJson = _repo.toJson(newElement);
+    final oldJson = _repo.toJson(oldElement);
 
     newJson['id'] = oldJson['id'];
     newJson['startDateTime'] = oldJson['startDateTime'];
     newJson['endDateTime'] = oldJson['endDateTime'];
     newJson['additionalInfo'] = oldJson['additionalInfo'];
 
-    return GrafikElementDto.fromJson(newJson).toDomain();
+    return _repo.fromJson(newJson);
   }
 
   GrafikElement updateField(
@@ -27,7 +28,7 @@ class GrafikElementFormAdapter {
     String field,
     dynamic value,
   ) {
-    final map = GrafikElementDto.fromDomain(element).toJson();
+    final map = _repo.toJson(element);
     if (field == 'startDateTime' || field == 'endDateTime') {
       if (value is DateTime) {
         map[field] = value;
@@ -36,18 +37,18 @@ class GrafikElementFormAdapter {
       map[field] = value;
     }
 
-    return GrafikElementDto.fromJson(map).toDomain();
+    return _repo.fromJson(map);
   }
 
   GrafikElement copyWithOverrides(
     GrafikElement element,
     Map<String, dynamic> overrides,
   ) {
-    final map = GrafikElementDto.fromDomain(element).toJson();
+    final map = _repo.toJson(element);
     overrides.forEach((key, val) {
       map[key] = val;
     });
-    return GrafikElementDto.fromJson(map).toDomain();
+    return _repo.fromJson(map);
   }
 
   GrafikElement fillMeta(GrafikElement element, String userId) {
@@ -56,10 +57,10 @@ class GrafikElementFormAdapter {
 
     if (!needUser && !needTs) return element;
 
-    final json = GrafikElementDto.fromDomain(element).toJson();
+    final json = _repo.toJson(element);
     if (needUser) json['addedByUserId'] = userId;
     if (needTs) json['addedTimestamp'] = DateTime.now();
 
-    return GrafikElementDto.fromJson(json).toDomain();
+    return _repo.fromJson(json);
   }
 }

--- a/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
@@ -1,12 +1,14 @@
 import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../injection.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import 'grafik_element_form_strategy.dart';
 
 class DeliveryPlanningElementStrategy implements GrafikElementFormStrategy {
-  final GrafikElementFormAdapter _adapter = GrafikElementFormAdapter();
+  final GrafikElementFormAdapter _adapter =
+      GrafikElementFormAdapter(repo: getIt<GrafikElementRepository>());
 
   @override
   GrafikElement createDefault() {

--- a/feature/grafik/form/strategy/task_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_element_strategy.dart
@@ -1,5 +1,6 @@
 import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../injection.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/task_element.dart';
@@ -7,7 +8,8 @@ import '../../../../domain/models/grafik/impl/task_template.dart';
 import 'grafik_element_form_strategy.dart';
 
 class TaskElementStrategy implements GrafikElementFormStrategy {
-  final GrafikElementFormAdapter _adapter = GrafikElementFormAdapter();
+  final GrafikElementFormAdapter _adapter =
+      GrafikElementFormAdapter(repo: getIt<GrafikElementRepository>());
 
   @override
   GrafikElement createDefault() {

--- a/feature/grafik/form/strategy/task_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_planning_element_strategy.dart
@@ -1,12 +1,14 @@
 import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../injection.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/task_planning_element.dart';
 import 'grafik_element_form_strategy.dart';
 
 class TaskPlanningElementStrategy implements GrafikElementFormStrategy {
-  final GrafikElementFormAdapter _adapter = GrafikElementFormAdapter();
+  final GrafikElementFormAdapter _adapter =
+      GrafikElementFormAdapter(repo: getIt<GrafikElementRepository>());
 
   @override
   GrafikElement createDefault() {

--- a/feature/grafik/form/strategy/time_issue_element_strategy.dart
+++ b/feature/grafik/form/strategy/time_issue_element_strategy.dart
@@ -1,12 +1,14 @@
 import '../grafik_element_form_adapter.dart';
 import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../injection.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/time_issue_element.dart';
 import 'grafik_element_form_strategy.dart';
 
 class TimeIssueElementStrategy implements GrafikElementFormStrategy {
-  final GrafikElementFormAdapter _adapter = GrafikElementFormAdapter();
+  final GrafikElementFormAdapter _adapter =
+      GrafikElementFormAdapter(repo: getIt<GrafikElementRepository>());
 
   @override
   GrafikElement createDefault() {


### PR DESCRIPTION
## Summary
- add DTO/JSON helpers to `GrafikElementRepository`
- refactor `GrafikElementFormAdapter` to depend on the repository
- inject the repository when creating form adapters in strategy classes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e465be45483339a0ca5c7d9bc80f0