### PR TITLE
Remove repository imports from grafik feature

### DIFF
--- a/feature/grafik/cubit/form/grafik_element_form_cubit.dart
+++ b/feature/grafik/cubit/form/grafik_element_form_cubit.dart
@@ -1,7 +1,7 @@
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../domain/services/i_grafik_element_service.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../form/grafik_element_registry.dart';
 import '../../../../domain/models/grafik/impl/task_template.dart';
@@ -10,7 +10,7 @@ import 'grafik_element_form_state.dart';
 
 // ───────── CUBIT ─────────
 class GrafikElementFormCubit extends Cubit<GrafikElementFormState> {
-  final GrafikElementRepository grafikService;
+  final IGrafikElementService grafikService;
   late GrafikElementFormStrategy _strategy;
 
   GrafikElementFormCubit({

--- a/feature/grafik/form/grafik_element_form_screen.dart
+++ b/feature/grafik/form/grafik_element_form_screen.dart
@@ -9,7 +9,7 @@ import 'components/type_dropdown.dart';
 import '../../../shared/form/custom_button.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
-import '../../../data/repositories/grafik_element_repository.dart';
+import '../../../domain/services/i_grafik_element_service.dart';
 
 class GrafikElementFormScreen extends StatelessWidget {
   final GrafikElement? existingElement;
@@ -20,7 +20,7 @@ class GrafikElementFormScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) => GrafikElementFormCubit(
-        grafikService: getIt<GrafikElementRepository>(),
+        grafikService: getIt<IGrafikElementService>(),
       )..initialize(existingElement),
       child: BlocConsumer<GrafikElementFormCubit, GrafikElementFormState>(
         listener: (context, state) {

--- a/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
@@ -1,5 +1,5 @@
 import '../grafik_element_form_adapter.dart';
-import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../domain/services/i_grafik_element_service.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/delivery_planning_element.dart';
@@ -32,7 +32,7 @@ class DeliveryPlanningElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
-  Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
-    await repo.saveGrafikElement(element);
+  Future<void> save(IGrafikElementService service, GrafikElement element) async {
+    await service.upsertGrafikElement(element);
   }
 }

--- a/feature/grafik/form/strategy/grafik_element_form_strategy.dart
+++ b/feature/grafik/form/strategy/grafik_element_form_strategy.dart
@@ -1,4 +1,4 @@
-import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../domain/services/i_grafik_element_service.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/task_template.dart';
 
@@ -19,7 +19,7 @@ abstract class GrafikElementFormStrategy {
   }
 
   Future<void> save(
-    GrafikElementRepository repo,
+    IGrafikElementService service,
     GrafikElement element,
   );
 }

--- a/feature/grafik/form/strategy/task_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_element_strategy.dart
@@ -1,5 +1,5 @@
 import '../grafik_element_form_adapter.dart';
-import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../domain/services/i_grafik_element_service.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/task_element.dart';
@@ -56,13 +56,13 @@ class TaskElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
-  Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
+  Future<void> save(IGrafikElementService service, GrafikElement element) async {
     if (element is! TaskElement) return;
     var task = element;
     if (task.id.isEmpty) {
-      final newId = repo.generateNewTaskId();
+      final newId = service.generateNewTaskId();
       task = task.copyWithId(newId);
     }
-    await repo.saveGrafikElement(task);
+    await service.upsertGrafikElement(task);
   }
 }

--- a/feature/grafik/form/strategy/task_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_planning_element_strategy.dart
@@ -1,5 +1,5 @@
 import '../grafik_element_form_adapter.dart';
-import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../domain/services/i_grafik_element_service.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/task_planning_element.dart';
@@ -37,7 +37,7 @@ class TaskPlanningElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
-  Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
-    await repo.saveGrafikElement(element);
+  Future<void> save(IGrafikElementService service, GrafikElement element) async {
+    await service.upsertGrafikElement(element);
   }
 }

--- a/feature/grafik/form/strategy/time_issue_element_strategy.dart
+++ b/feature/grafik/form/strategy/time_issue_element_strategy.dart
@@ -1,5 +1,5 @@
 import '../grafik_element_form_adapter.dart';
-import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../domain/services/i_grafik_element_service.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/time_issue_element.dart';
@@ -33,7 +33,7 @@ class TimeIssueElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
-  Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
-    await repo.saveGrafikElement(element);
+  Future<void> save(IGrafikElementService service, GrafikElement element) async {
+    await service.upsertGrafikElement(element);
   }
 }

--- a/feature/grafik/form/task_element_fields.dart
+++ b/feature/grafik/form/task_element_fields.dart
@@ -11,7 +11,7 @@ import '../../../shared/form/enum_picker/enum_picker.dart';
 import '../../employee/employee_picker.dart';
 import '../../vehicle/widget/vehicle_picker.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
-import '../../../../data/repositories/employee_repository.dart';
+import '../../../domain/services/i_employee_service.dart';
 import '../../../../data/repositories/vehicle_repository.dart';
 
 class TaskFields extends StatelessWidget {
@@ -63,7 +63,7 @@ class TaskFields extends StatelessWidget {
         const SizedBox(height: AppSpacing.sm * 2),
 
         EmployeePicker(
-          employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
+          employeeStream: GetIt.I<IEmployeeService>().getEmployeesStream(),
           initialSelectedIds: element.workerIds,
           onSelectionChanged: (selectedEmployees) {
             final ids = selectedEmployees.map((e) => e.uid).toList();

--- a/feature/grafik/form/task_planning_element_fields.dart
+++ b/feature/grafik/form/task_planning_element_fields.dart
@@ -3,7 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:kabast/theme/app_tokens.dart';
 
-import '../../../data/repositories/employee_repository.dart';
+import '../../../domain/services/i_employee_service.dart';
 import '../../../domain/models/grafik/enums.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../../shared/form/bool_picker/bool_toggle_field.dart';
@@ -41,7 +41,7 @@ class GrafikPlanningFields extends StatelessWidget {
         const SizedBox(height: AppSpacing.sm * 2),
 
         EmployeePicker(
-          employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
+          employeeStream: GetIt.I<IEmployeeService>().getEmployeesStream(),
           initialSelectedIds: element.workerIds,
           onSelectionChanged: (selectedEmployees) {
             final ids = selectedEmployees.map((e) => e.uid).toList();

--- a/feature/grafik/form/time_issue_element_fields.dart
+++ b/feature/grafik/form/time_issue_element_fields.dart
@@ -8,7 +8,7 @@ import '../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
 import '../../employee/employee_picker.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
-import '../../../../data/repositories/employee_repository.dart';
+import '../../../domain/services/i_employee_service.dart';
 
 class TimeIssueFields extends StatelessWidget {
   final TimeIssueElement element;
@@ -32,7 +32,7 @@ class TimeIssueFields extends StatelessWidget {
 
         EmployeePicker(
           singleSelection: true,
-          employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
+          employeeStream: GetIt.I<IEmployeeService>().getEmployeesStream(),
           initialSelectedIds: [element.workerId],
           onSelectionChanged: (selectedEmployees) {
             if (selectedEmployees.isNotEmpty) {

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import 'package:kabast/data/repositories/grafik_element_repository.dart';
+import 'package:kabast/domain/services/i_grafik_element_service.dart';
 import 'package:kabast/data/repositories/app_user_repository.dart';
 import 'package:kabast/domain/models/grafik/grafik_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
@@ -49,7 +49,7 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
   GrafikStatus? _status;
   GrafikElement get _element => widget.element;
 
-  final _repo = getIt<GrafikElementRepository>();
+  final _repo = getIt<IGrafikElementService>();
   final _userRepo = getIt<AppUserRepository>();
   String? _userFullName;
 
@@ -156,7 +156,7 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
               permission: 'canEditGrafik',
               child: TextButton(
                 onPressed: () {
-                  getIt<GrafikElementRepository>().deleteGrafikElement(_element.id);
+                  getIt<IGrafikElementService>().deleteGrafikElement(_element.id);
                   Navigator.of(context).pop();
                 },
                 child: const Text('Usuń'),

--- a/injection.dart
+++ b/injection.dart
@@ -79,9 +79,9 @@ Future<void> setupLocator() async {
 
   getIt.registerFactory<GrafikCubit>(
     () => GrafikCubit(
-      getIt<GrafikElementRepository>(),
+      getIt<IGrafikElementService>(),
       getIt<VehicleWatcher>(),
-      getIt<EmployeeRepository>(),
+      getIt<IEmployeeService>(),
       getIt<DateCubit>(),
     ),
   );


### PR DESCRIPTION
## Summary
- avoid using repository classes directly in grafik feature
- update cubits and UI to depend on `IGrafikElementService` and `IEmployeeService`
- adjust injection for new dependencies

## Testing
- `dart format -o none -l 80 $(git ls-files '*.dart')` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e456a96bc8333bee38827a380aee4