### PR TITLE
Fix issueType cast for TimeIssueElement

### DIFF
--- a/feature/grafik/form/components/date_input_selector.dart
+++ b/feature/grafik/form/components/date_input_selector.dart
@@ -33,7 +33,8 @@ class DateInputSelector extends StatelessWidget {
 
     if (isTaskPlanning ||
         (element is TimeIssueElement &&
-            element.issueType == TimeIssueType.Nieobecnosc)) {
+            (element as TimeIssueElement).issueType ==
+                TimeIssueType.Nieobecnosc)) {
       return DateRangePickerButton(
         initialRange: DateTimeRange(
           start: element.startDateTime,


### PR DESCRIPTION
## Summary
- ensure `issueType` access only when the element is `TimeIssueElement`

## Testing
- `dart format feature/grafik/form/components/date_input_selector.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4db67bcc8333b96ebdcebdde0024