### PR TITLE
Implement applyTemplate in grafik strategies

### DIFF
--- a/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/delivery_planning_element_strategy.dart
@@ -34,6 +34,17 @@ class DeliveryPlanningElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
+  GrafikElement applyTemplate(GrafikElement element, GrafikElement template) {
+    if (template is! DeliveryPlanningElement) return element;
+    final overrides = getIt<GrafikElementRepository>().toJson(template)
+      ..remove('id');
+    return _adapter.copyWithOverrides(
+      element.type == template.type ? element : _adapter.changeType(element, template.type),
+      overrides,
+    );
+  }
+
+  @override
   Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
     await repo.saveGrafikElement(element);
   }

--- a/feature/grafik/form/strategy/grafik_element_form_strategy.dart
+++ b/feature/grafik/form/strategy/grafik_element_form_strategy.dart
@@ -1,6 +1,5 @@
 import '../../../../data/repositories/grafik_element_repository.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
-import '../../../../domain/models/grafik/impl/task_template.dart';
 
 abstract class GrafikElementFormStrategy {
   GrafikElement createDefault();
@@ -13,10 +12,8 @@ abstract class GrafikElementFormStrategy {
 
   GrafikElement applyTemplate(
     GrafikElement element,
-    TaskTemplate template,
-  ) {
-    return element;
-  }
+    GrafikElement template,
+  );
 
   Future<void> save(
     GrafikElementRepository repo,

--- a/feature/grafik/form/strategy/task_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_element_strategy.dart
@@ -4,7 +4,6 @@ import '../../../../injection.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../../../domain/models/grafik/grafik_element.dart';
 import '../../../../domain/models/grafik/impl/task_element.dart';
-import '../../../../domain/models/grafik/impl/task_template.dart';
 import 'grafik_element_form_strategy.dart';
 
 class TaskElementStrategy implements GrafikElementFormStrategy {
@@ -38,23 +37,14 @@ class TaskElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
-  GrafikElement applyTemplate(GrafikElement element, TaskTemplate tpl) {
+  GrafikElement applyTemplate(GrafikElement element, GrafikElement template) {
+    if (template is! TaskElement) return element;
     TaskElement task = element is TaskElement
         ? element
         : createDefault() as TaskElement;
-    final day = task.startDateTime;
-    final newStart = DateTime(day.year, day.month, day.day, tpl.startHour);
-    final newEnd = DateTime(day.year, day.month, day.day, tpl.endHour);
-    return task.copyWith(
-      startDateTime: newStart,
-      endDateTime: newEnd,
-      taskType: tpl.taskType,
-      status: tpl.status,
-      orderId: tpl.orderId,
-      workerIds: tpl.workerIds,
-      carIds: tpl.carIds,
-      additionalInfo: tpl.additionalInfo,
-    );
+    final overrides = getIt<GrafikElementRepository>().toJson(template)
+      ..remove('id');
+    return _adapter.copyWithOverrides(task, overrides);
   }
 
   @override

--- a/feature/grafik/form/strategy/task_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_planning_element_strategy.dart
@@ -39,6 +39,17 @@ class TaskPlanningElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
+  GrafikElement applyTemplate(GrafikElement element, GrafikElement template) {
+    if (template is! TaskPlanningElement) return element;
+    final overrides = getIt<GrafikElementRepository>().toJson(template)
+      ..remove('id');
+    return _adapter.copyWithOverrides(
+      element.type == template.type ? element : _adapter.changeType(element, template.type),
+      overrides,
+    );
+  }
+
+  @override
   Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
     await repo.saveGrafikElement(element);
   }

--- a/feature/grafik/form/strategy/time_issue_element_strategy.dart
+++ b/feature/grafik/form/strategy/time_issue_element_strategy.dart
@@ -35,6 +35,17 @@ class TimeIssueElementStrategy implements GrafikElementFormStrategy {
   }
 
   @override
+  GrafikElement applyTemplate(GrafikElement element, GrafikElement template) {
+    if (template is! TimeIssueElement) return element;
+    final overrides = getIt<GrafikElementRepository>().toJson(template)
+      ..remove('id');
+    return _adapter.copyWithOverrides(
+      element.type == template.type ? element : _adapter.changeType(element, template.type),
+      overrides,
+    );
+  }
+
+  @override
   Future<void> save(GrafikElementRepository repo, GrafikElement element) async {
     await repo.saveGrafikElement(element);
   }


### PR DESCRIPTION
## Summary
- add `applyTemplate(GrafikElement, GrafikElement)` to `GrafikElementFormStrategy`
- implement the new method for all element strategies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e4d7f79a48333a83bc3644bb0b0c2