### PR TITLE
Fix responsive layout

### DIFF
--- a/feature/auth/screen/login_screen.dart
+++ b/feature/auth/screen/login_screen.dart
@@ -24,41 +24,53 @@ class LoginScreen extends StatelessWidget {
         }
       },
       child: Scaffold(
-        body: Padding(
-          padding: const EdgeInsets.all(AppSpacing.sm * 4),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Image.asset(
-                AppAssets.logoGradient,
-                height: 100,
-                semanticLabel: AppStrings.logoAlt,
-              ),
-              const SizedBox(height: AppSpacing.sm * 3),
-              TextField(
-                key: const ValueKey('login-email'),
-                onChanged: authCubit.updateLoginEmail,
-                decoration: const InputDecoration(labelText: AppStrings.email),
-              ),
-              const SizedBox(height: AppSpacing.sm * 3),
-              TextField(
-                key: const ValueKey('login-password'),
-                onChanged: authCubit.updateLoginPassword,
-                obscureText: true,
-                decoration: const InputDecoration(labelText: AppStrings.password),
-              ),
-              const SizedBox(height: AppSpacing.sm * 6),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  TextButton(
-                    onPressed: authCubit.signIn,
-                    child: const Text(AppStrings.login),
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(AppSpacing.sm * 4),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight,
+                  maxWidth: 400,
+                ),
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Image.asset(
+                        AppAssets.logoGradient,
+                        height: 100,
+                        semanticLabel: AppStrings.logoAlt,
+                      ),
+                      const SizedBox(height: AppSpacing.sm * 3),
+                      TextField(
+                        key: const ValueKey('login-email'),
+                        onChanged: authCubit.updateLoginEmail,
+                        decoration: const InputDecoration(labelText: AppStrings.email),
+                      ),
+                      const SizedBox(height: AppSpacing.sm * 3),
+                      TextField(
+                        key: const ValueKey('login-password'),
+                        onChanged: authCubit.updateLoginPassword,
+                        obscureText: true,
+                        decoration: const InputDecoration(labelText: AppStrings.password),
+                      ),
+                      const SizedBox(height: AppSpacing.sm * 6),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          TextButton(
+                            onPressed: authCubit.signIn,
+                            child: const Text(AppStrings.login),
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
-            ],
-          ),
+            );
+          },
         ),
       ),
     );

--- a/feature/auth/screen/register_user_widget.dart
+++ b/feature/auth/screen/register_user_widget.dart
@@ -24,30 +24,42 @@ class RegisterUserWidget extends StatelessWidget {
         }
       },
       child: Scaffold(
-        body: Padding(
-          padding: const EdgeInsets.all(AppSpacing.sm * 4),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              TextField(
-                key: const ValueKey('register-email'),
-                onChanged: authCubit.updateLoginEmail,
-                decoration: const InputDecoration(labelText: AppStrings.email),
+        body: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(AppSpacing.sm * 4),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight,
+                  maxWidth: 400,
+                ),
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      TextField(
+                        key: const ValueKey('register-email'),
+                        onChanged: authCubit.updateLoginEmail,
+                        decoration: const InputDecoration(labelText: AppStrings.email),
+                      ),
+                      const SizedBox(height: AppSpacing.sm * 3),
+                      TextField(
+                        key: const ValueKey('register-password'),
+                        onChanged: authCubit.updateLoginPassword,
+                        obscureText: true,
+                        decoration: const InputDecoration(labelText: AppStrings.password),
+                      ),
+                      const SizedBox(height: AppSpacing.sm * 6),
+                      ElevatedButton(
+                        onPressed: authCubit.signUp,
+                        child: const Text(AppStrings.registerUser),
+                      ),
+                    ],
+                  ),
+                ),
               ),
-              const SizedBox(height: AppSpacing.sm * 3),
-              TextField(
-                key: const ValueKey('register-password'),
-                onChanged: authCubit.updateLoginPassword,
-                obscureText: true,
-                decoration: const InputDecoration(labelText: AppStrings.password),
-              ),
-              const SizedBox(height: AppSpacing.sm * 6),
-              ElevatedButton(
-                onPressed: authCubit.signUp,
-                child: const Text(AppStrings.registerUser),
-              ),
-            ],
-          ),
+            );
+          },
         ),
       ),
     );

--- a/feature/extra_options/extra_options_screen.dart
+++ b/feature/extra_options/extra_options_screen.dart
@@ -9,14 +9,21 @@ class ExtraOptionsScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Dodatkowe opcje'),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Text(
-            'Dwa tygodnei zdalnego i mogą być tu cuda',
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-        ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16.0),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(
+                child: Text(
+                  'Dwa tygodnei zdalnego i mogą być tu cuda',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/feature/grafik/widget/pending_task_column.dart
+++ b/feature/grafik/widget/pending_task_column.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_state.dart';
+import 'package:kabast/theme/size_variants.dart';
 
 import 'week/tiles/task_planning_week_tile.dart';
 
@@ -39,11 +40,10 @@ class PendingTasksColumn extends StatelessWidget {
           itemCount: pending.length,
           separatorBuilder: (_, __) => const SizedBox(height: 8),
           itemBuilder: (context, index) => SizedBox(
-            height: 192, // 🔥 sztywna wysokość kafelka
+            height: SizeVariant.big.height * 4,
             child: TaskPlanningWeekTile(taskPlanning: pending[index]),
           ),
         );
       },
     );
-  }
-}
+  }}

--- a/feature/grafik/widget/week/week_grafik_view.dart
+++ b/feature/grafik/widget/week/week_grafik_view.dart
@@ -65,13 +65,13 @@ class WeekGrafikView extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 //  ←  5‑dniowy grafik
-                const Expanded(child: GrafikPlanningStack()),
+                const Expanded(flex: 3, child: GrafikPlanningStack()),
 
                 const SizedBox(width: 12),
 
-                //  →  „Wisi‑grozi”  – 200 px
-                SizedBox(
-                  width: 200,
+                // -> Wisi-grozi column
+                Flexible(
+                  flex: 1,
                   child: PendingTasksColumn(),
                 ),
               ],

--- a/shared/responsive/responsive_chip.dart
+++ b/shared/responsive/responsive_chip.dart
@@ -23,7 +23,10 @@ class ResponsiveChip extends StatelessWidget {
             label,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: TextStyle(color: textColor, fontSize: 22),
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(color: textColor),
           ),
         ),
       padding: EdgeInsets.symmetric(horizontal: 2, vertical: 1),

--- a/shared/small_chip.dart
+++ b/shared/small_chip.dart
@@ -50,7 +50,9 @@ class SmallChip extends StatelessWidget {
       onTap: onTap,
       child: Container(
         // Ograniczamy maksymalną szerokość chipu, aby nie powodował overflow
-        constraints: const BoxConstraints(maxWidth: 120),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.3,
+        ),
         margin: const EdgeInsets.all(AppSpacing.xxs), // 1.0
         padding: const EdgeInsets.symmetric(
           horizontal: AppSpacing.xs, // 2.0

--- a/theme/size_variants.dart
+++ b/theme/size_variants.dart
@@ -4,24 +4,30 @@ import 'package:flutter/material.dart';
 enum SizeVariant { big, medium, small }
 
 extension SizeVariantSpec on SizeVariant {
+  double get _scale {
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final width = view.physicalSize.width / view.devicePixelRatio;
+    return (width / 400).clamp(0.8, 1.2);
+  }
+
   /// Wysokość kafelka ‑ **musi być taka sama** we wszystkich delegatach.
   double get height => switch (this) {
-    SizeVariant.big    => 48,  // px
-    SizeVariant.medium => 32,
-    SizeVariant.small  => 20,
+    SizeVariant.big    => 48 * _scale,
+    SizeVariant.medium => 32 * _scale,
+    SizeVariant.small  => 20 * _scale,
   };
 
   /// Domyślny rozmiar ikon.
   double get iconSize => switch (this) {
-    SizeVariant.big    => 20,
-    SizeVariant.medium => 16,
-    SizeVariant.small  => 14,
+    SizeVariant.big    => 20 * _scale,
+    SizeVariant.medium => 16 * _scale,
+    SizeVariant.small  => 14 * _scale,
   };
 
   /// Spójny styl tekstu (height = 1 ⇒ brak dodatkowego leadingu).
   TextStyle get textStyle => switch (this) {
-    SizeVariant.big    => const TextStyle(fontSize: 18, height: 1),
-    SizeVariant.medium => const TextStyle(fontSize: 14, height: 1),
-    SizeVariant.small  => const TextStyle(fontSize: 12, height: 1),
+    SizeVariant.big    => TextStyle(fontSize: 18 * _scale, height: 1),
+    SizeVariant.medium => TextStyle(fontSize: 14 * _scale, height: 1),
+    SizeVariant.small  => TextStyle(fontSize: 12 * _scale, height: 1),
   };
 }

--- a/theme/theme.dart
+++ b/theme/theme.dart
@@ -3,6 +3,10 @@ import 'app_tokens.dart';
 
 class AppTheme {
   static ThemeData buildTheme() {
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final width = view.physicalSize.width / view.devicePixelRatio;
+    final scale = (width / 400).clamp(0.8, 1.2);
+
     return ThemeData(
       useMaterial3: false,
       colorScheme: ColorScheme.fromSeed(
@@ -13,10 +17,10 @@ class AppTheme {
 
       appBarTheme: AppBarTheme(
         backgroundColor: Colors.white,
-        titleTextStyle: const TextStyle(
-          fontSize: 16,
+        titleTextStyle: TextStyle(
+          fontSize: 16 * scale,
           fontWeight: FontWeight.w600,
-          color: Color(0xFF1565C0),
+          color: const Color(0xFF1565C0),
         ),
         iconTheme: const IconThemeData(color: Color(0xFF1565C0)),
         actionsIconTheme: const IconThemeData(color: Color(0xFF1565C0)),
@@ -26,16 +30,16 @@ class AppTheme {
         ),
       ),
 
-      textTheme: const TextTheme(
-        bodyLarge: TextStyle(fontSize: 22),
-        bodyMedium: TextStyle(fontSize: 20),
-        bodySmall: TextStyle(fontSize: 18),
-        titleLarge: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-        labelLarge: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      textTheme: TextTheme(
+        bodyLarge: TextStyle(fontSize: 22 * scale),
+        bodyMedium: TextStyle(fontSize: 20 * scale),
+        bodySmall: TextStyle(fontSize: 18 * scale),
+        titleLarge: TextStyle(fontSize: 22 * scale, fontWeight: FontWeight.bold),
+        labelLarge: TextStyle(fontSize: 18 * scale, fontWeight: FontWeight.bold),
         //Wykorzystywane turbo_grid
-        displaySmall: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-        displayMedium: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        displayLarge: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+        displaySmall: TextStyle(fontSize: 14 * scale, fontWeight: FontWeight.bold),
+        displayMedium: TextStyle(fontSize: 18 * scale, fontWeight: FontWeight.bold),
+        displayLarge: TextStyle(fontSize: 22 * scale, fontWeight: FontWeight.bold),
       ),
 
       elevatedButtonTheme: ElevatedButtonThemeData(
@@ -89,9 +93,9 @@ class AppTheme {
         ),
         selectedColor: const Color(0xFF64B5F6),
         backgroundColor: Colors.grey.shade200,
-        labelStyle: const TextStyle(
-          fontSize: 16,
-          color: Color(0xFF1565C0),
+        labelStyle: TextStyle(
+          fontSize: 16 * scale,
+          color: const Color(0xFF1565C0),
         ),
       ),
 


### PR DESCRIPTION
## Summary
- enable scrolling and layout centering in login & register widgets
- adapt week grafik view and pending tasks to flexible sizes
- scale tile sizes via screen width
- add responsive fonts in theme
- tweak chip widgets and extra options screen for small screens

## Testing
- `dart`/`flutter` not available, so manual formatting applied


------
https://chatgpt.com/codex/tasks/task_e_686e6e0a92808333b9501c549318f51f