### PR TITLE
Avoid overwriting existing user records

### DIFF
--- a/data/repositories/app_user_repository.dart
+++ b/data/repositories/app_user_repository.dart
@@ -13,4 +13,8 @@ class AppUserRepository {
   Stream<AppUser?> getUserStream(String uid) {
     return _service.getAppUserStream(uid);
   }
+
+  Future<AppUser?> getUser(String uid) {
+    return _service.getAppUser(uid);
+  }
 }

--- a/data/services/app_user_firebase_service.dart
+++ b/data/services/app_user_firebase_service.dart
@@ -10,7 +10,17 @@ class AppUserFirebaseService implements IAppUserService {
 
   Future<void> upsertAppUser(AppUser user) async {
     final dto = AppUserDto.fromDomain(user);
-    await _firestore.collection('users').doc(user.id).set(dto.toJson());
+    await _firestore
+        .collection('users')
+        .doc(user.id)
+        .set(dto.toJson(), SetOptions(merge: true));
+  }
+
+  @override
+  Future<AppUser?> getAppUser(String uid) async {
+    final doc = await _firestore.collection('users').doc(uid).get();
+    if (!doc.exists) return null;
+    return AppUserDto.fromFirestore(doc).toDomain();
   }
 
   Stream<AppUser?> getAppUserStream(String uid) {

--- a/data/services/auth_firebase_service.dart
+++ b/data/services/auth_firebase_service.dart
@@ -16,7 +16,7 @@ class AuthFirebaseService implements IAuthService {
         yield null;
         return;
       }
-      final existing = await _userRepository.getUserStream(user.uid).first;
+      final existing = await _userRepository.getUser(user.uid);
       if (existing == null) {
         final newUser = AppUser.defaultUser(
           id: user.uid,

--- a/domain/services/i_app_user_service.dart
+++ b/domain/services/i_app_user_service.dart
@@ -3,4 +3,5 @@ import '../models/app_user.dart';
 abstract class IAppUserService {
   Future<void> upsertAppUser(AppUser user);
   Stream<AppUser?> getAppUserStream(String uid);
+  Future<AppUser?> getAppUser(String uid);
 }


### PR DESCRIPTION
## Summary
- add single user getter to `IAppUserService`
- add `getUser` in repository and Firebase service
- use direct fetch in `AuthFirebaseService` to check for existing user
- set Firestore user documents with merge to preserve fields

## Testing
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e953a729c8333bdfc328803fcea85