### PR TITLE
Add task assignment model and services

### DIFF
--- a/data/dto/grafik/task_assignment_dto.dart
+++ b/data/dto/grafik/task_assignment_dto.dart
@@ -1,0 +1,66 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../domain/models/grafik/task_assignment.dart';
+
+class TaskAssignmentDto {
+  final String taskId;
+  final String workerId;
+  final DateTime startDateTime;
+  final DateTime endDateTime;
+
+  TaskAssignmentDto({
+    required this.taskId,
+    required this.workerId,
+    required this.startDateTime,
+    required this.endDateTime,
+  });
+
+  factory TaskAssignmentDto.fromJson(Map<String, dynamic> json) {
+    DateTime parse(dynamic value) {
+      if (value is Timestamp) return value.toDate();
+      if (value is DateTime) return value;
+      if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);
+      if (value is String) return DateTime.tryParse(value) ?? DateTime.now();
+      return DateTime.now();
+    }
+
+    return TaskAssignmentDto(
+      taskId: json['taskId'] as String? ?? '',
+      workerId: json['workerId'] as String? ?? '',
+      startDateTime: parse(json['startDateTime']),
+      endDateTime: parse(json['endDateTime']),
+    );
+  }
+
+  factory TaskAssignmentDto.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    return TaskAssignmentDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'taskId': taskId,
+      'workerId': workerId,
+      'startDateTime': Timestamp.fromDate(startDateTime),
+      'endDateTime': Timestamp.fromDate(endDateTime),
+    };
+  }
+
+  TaskAssignment toDomain() {
+    return TaskAssignment(
+      taskId: taskId,
+      workerId: workerId,
+      startDateTime: startDateTime,
+      endDateTime: endDateTime,
+    );
+  }
+
+  factory TaskAssignmentDto.fromDomain(TaskAssignment assignment) {
+    return TaskAssignmentDto(
+      taskId: assignment.taskId,
+      workerId: assignment.workerId,
+      startDateTime: assignment.startDateTime,
+      endDateTime: assignment.endDateTime,
+    );
+  }
+}

--- a/data/repositories/task_assignment_repository.dart
+++ b/data/repositories/task_assignment_repository.dart
@@ -1,0 +1,16 @@
+import '../../domain/models/grafik/task_assignment.dart';
+import '../../domain/services/i_task_assignment_service.dart';
+
+class TaskAssignmentRepository {
+  final ITaskAssignmentService _service;
+
+  TaskAssignmentRepository(this._service);
+
+  Stream<List<TaskAssignment>> getAssignmentsForTask(String taskId) {
+    return _service.getAssignmentsForTask(taskId);
+  }
+
+  Future<void> saveTaskAssignment(TaskAssignment assignment) {
+    return _service.addTaskAssignment(assignment);
+  }
+}

--- a/data/services/task_assignment_firebase_service.dart
+++ b/data/services/task_assignment_firebase_service.dart
@@ -1,0 +1,28 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/models/grafik/task_assignment.dart';
+import '../../domain/services/i_task_assignment_service.dart';
+import '../dto/grafik/task_assignment_dto.dart';
+
+class TaskAssignmentFirebaseService implements ITaskAssignmentService {
+  final FirebaseFirestore _firestore;
+
+  TaskAssignmentFirebaseService(this._firestore);
+
+  @override
+  Stream<List<TaskAssignment>> getAssignmentsForTask(String taskId) {
+    return _firestore
+        .collection('task_assignments')
+        .where('taskId', isEqualTo: taskId)
+        .snapshots()
+        .map((query) => query.docs
+            .map((doc) => TaskAssignmentDto.fromFirestore(doc).toDomain())
+            .toList());
+  }
+
+  @override
+  Future<void> addTaskAssignment(TaskAssignment assignment) async {
+    final dto = TaskAssignmentDto.fromDomain(assignment);
+    await _firestore.collection('task_assignments').add(dto.toJson());
+  }
+}

--- a/domain/models/grafik/task_assignment.dart
+++ b/domain/models/grafik/task_assignment.dart
@@ -1,0 +1,27 @@
+class TaskAssignment {
+  final String taskId;
+  final String workerId;
+  final DateTime startDateTime;
+  final DateTime endDateTime;
+
+  TaskAssignment({
+    required this.taskId,
+    required this.workerId,
+    required this.startDateTime,
+    required this.endDateTime,
+  });
+
+  TaskAssignment copyWith({
+    String? taskId,
+    String? workerId,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
+  }) {
+    return TaskAssignment(
+      taskId: taskId ?? this.taskId,
+      workerId: workerId ?? this.workerId,
+      startDateTime: startDateTime ?? this.startDateTime,
+      endDateTime: endDateTime ?? this.endDateTime,
+    );
+  }
+}

--- a/domain/services/i_task_assignment_service.dart
+++ b/domain/services/i_task_assignment_service.dart
@@ -1,0 +1,6 @@
+import '../models/grafik/task_assignment.dart';
+
+abstract class ITaskAssignmentService {
+  Stream<List<TaskAssignment>> getAssignmentsForTask(String taskId);
+  Future<void> addTaskAssignment(TaskAssignment assignment);
+}

--- a/injection.dart
+++ b/injection.dart
@@ -23,6 +23,9 @@ import 'package:kabast/feature/date/date_cubit.dart';
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
+import 'package:kabast/data/services/task_assignment_firebase_service.dart';
+import 'package:kabast/data/repositories/task_assignment_repository.dart';
+import 'package:kabast/domain/services/i_task_assignment_service.dart';
 final getIt = GetIt.instance;
 
 Future<void> setupLocator() async {
@@ -46,6 +49,9 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<IGrafikElementService>(
     () => GrafikElementFirebaseService(getIt<FirebaseFirestore>()),
   );
+  getIt.registerLazySingleton<ITaskAssignmentService>(
+    () => TaskAssignmentFirebaseService(getIt<FirebaseFirestore>()),
+  );
 
   // Repozytoria
   getIt.registerLazySingleton<AppUserRepository>(
@@ -62,6 +68,9 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<GrafikElementRepository>(
     () => GrafikElementRepository(getIt<IGrafikElementService>()),
+  );
+  getIt.registerLazySingleton<TaskAssignmentRepository>(
+    () => TaskAssignmentRepository(getIt<ITaskAssignmentService>()),
   );
   getIt.registerLazySingleton<IGrafikResolver>(
     () => GrafikResolver(getIt<GrafikElementRepository>()),


### PR DESCRIPTION
## Summary
- model worker task assignment with start and end time
- DTO to convert assignments from/to Firestore
- Firebase service and repository for assignments
- register new service and repository in dependency injection

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e991353a88333bee92759ffb4ff14