### PR TITLE
Add employee work time report

### DIFF
--- a/data/repositories/assignment_repository.dart
+++ b/data/repositories/assignment_repository.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import '../../domain/models/grafik/impl/task_element.dart';
+import 'grafik_element_repository.dart';
+
+class AssignmentRepository {
+  final GrafikElementRepository _grafikRepo;
+
+  AssignmentRepository(this._grafikRepo);
+
+  /// Returns the total work time of [workerId] within the given period.
+  /// The result is the sum of task durations (in minutes) where
+  /// the employee is assigned.
+  Future<Duration> getTotalWorkTime({
+    required String workerId,
+    required DateTime start,
+    required DateTime end,
+  }) async {
+    final elements = await _grafikRepo
+        .getElementsWithinRange(start: start, end: end, types: ['TaskElement'])
+        .first;
+
+    Duration total = Duration.zero;
+    for (final e in elements.whereType<TaskElement>()) {
+      if (!e.workerIds.contains(workerId)) continue;
+      final s = e.startDateTime.isBefore(start) ? start : e.startDateTime;
+      final f = e.endDateTime.isAfter(end) ? end : e.endDateTime;
+      final diff = f.difference(s);
+      if (diff.isNegative) continue;
+      total += diff;
+    }
+    return total;
+  }
+}

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -4,6 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import '../../../data/repositories/employee_repository.dart';
 import '../../../data/repositories/grafik_element_repository.dart';
+import '../../../data/repositories/assignment_repository.dart';
 import '../../../domain/services/i_vehicle_watcher_service.dart';
 import '../../date/date_cubit.dart';
 import '../../../domain/models/employee.dart';
@@ -25,6 +26,7 @@ class GrafikCubit extends Cubit<GrafikState> {
   final GrafikElementRepository _grafikRepo;
   final IVehicleWatcherService _vehicleWatcher;
   final EmployeeRepository _employeeRepo;
+  final AssignmentRepository _assignmentRepo;
   final DateCubit _dateCubit;
 
   late StreamSubscription<Map<String, dynamic>> _mappingSub;
@@ -36,6 +38,7 @@ class GrafikCubit extends Cubit<GrafikState> {
       this._grafikRepo,
       this._vehicleWatcher,
       this._employeeRepo,
+      this._assignmentRepo,
       this._dateCubit,
       ) : super(GrafikState.initial()) {
     _subscribeVehicles();
@@ -162,6 +165,18 @@ class GrafikCubit extends Cubit<GrafikState> {
     }, onError: (e) {
       emit(state.copyWith(error: e.toString()));
     });
+  }
+
+  Future<Duration> getTotalWorkTimeForEmployee({
+    required String workerId,
+    required DateTime start,
+    required DateTime end,
+  }) {
+    return _assignmentRepo.getTotalWorkTime(
+      workerId: workerId,
+      start: start,
+      end: end,
+    );
   }
 
   @override

--- a/injection.dart
+++ b/injection.dart
@@ -21,6 +21,7 @@ import 'package:kabast/feature/auth/auth_cubit.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
+import 'package:kabast/data/repositories/assignment_repository.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
 final getIt = GetIt.instance;
@@ -63,6 +64,9 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<GrafikElementRepository>(
     () => GrafikElementRepository(getIt<IGrafikElementService>()),
   );
+  getIt.registerLazySingleton<AssignmentRepository>(
+    () => AssignmentRepository(getIt<GrafikElementRepository>()),
+  );
   getIt.registerLazySingleton<IGrafikResolver>(
     () => GrafikResolver(getIt<GrafikElementRepository>()),
   );
@@ -88,6 +92,7 @@ Future<void> setupLocator() async {
       getIt<GrafikElementRepository>(),
       getIt<IVehicleWatcherService>(),
       getIt<EmployeeRepository>(),
+      getIt<AssignmentRepository>(),
       getIt<DateCubit>(),
     ),
   );

--- a/main.dart
+++ b/main.dart
@@ -20,6 +20,19 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   await setupLocator();
+  // Example usage of the work time report
+  final exampleCubit = GetIt.instance<GrafikCubit>();
+  final now = DateTime.now();
+  exampleCubit
+      .getTotalWorkTimeForEmployee(
+        workerId: 'demo-worker',
+        start: now.subtract(const Duration(days: 7)),
+        end: now,
+      )
+      .then((duration) {
+        print('Demo worker time last week: ${duration.inHours}h');
+        exampleCubit.close();
+      });
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
## Summary
- implement `AssignmentRepository` with work time aggregation
- expose this calculation via `GrafikCubit`
- wire new repository through dependency injection
- print example usage in `main`

## Testing
- `dart` and `flutter` were not available, so no format or unit tests were run


------
https://chatgpt.com/codex/tasks/task_e_686e9918db048333a5d9cd2a554d597e