### PR TITLE
Remove deprecated workerIds from TaskElement

### DIFF
--- a/data/dto/grafik/task_element_dto.dart
+++ b/data/dto/grafik/task_element_dto.dart
@@ -6,7 +6,6 @@ import 'grafik_element_dto.dart';
 import 'task_assignment_dto.dart';
 
 class TaskElementDto extends GrafikElementDto {
-  final List<String> workerIds;
   final String orderId;
   final GrafikStatus status;
   final GrafikTaskType taskType;
@@ -22,7 +21,6 @@ class TaskElementDto extends GrafikElementDto {
     required super.addedByUserId,
     required super.addedTimestamp,
     required super.closed,
-    required this.workerIds,
     required this.orderId,
     required this.status,
     required this.taskType,
@@ -49,7 +47,6 @@ class TaskElementDto extends GrafikElementDto {
         DateTime(1960, 2, 9),
       ),
       closed: json['closed'] as bool? ?? false,
-      workerIds: (json['workerIds'] as List?)?.cast<String>() ?? <String>[],
       orderId: json['orderId'] as String? ?? '',
       status: GrafikStatus.values.firstWhere(
         (e) => e.toString() == (json['status'] ?? 'GrafikStatus.Realizacja'),
@@ -70,7 +67,6 @@ class TaskElementDto extends GrafikElementDto {
 
   Map<String, dynamic> toJson() => {
         ...baseToJson(),
-        'workerIds': workerIds,
         'orderId': orderId,
         'status': status.toString(),
         'taskType': taskType.toString(),
@@ -83,7 +79,6 @@ class TaskElementDto extends GrafikElementDto {
         startDateTime: startDateTime,
         endDateTime: endDateTime,
         additionalInfo: additionalInfo,
-        workerIds: workerIds,
         orderId: orderId,
         status: status,
         taskType: taskType,
@@ -103,7 +98,6 @@ class TaskElementDto extends GrafikElementDto {
         addedByUserId: element.addedByUserId,
         addedTimestamp: element.addedTimestamp,
         closed: element.closed,
-        workerIds: List<String>.from(element.workerIds),
         orderId: element.orderId,
         status: element.status,
         taskType: element.taskType,

--- a/data/repositories/assignment_repository.dart
+++ b/data/repositories/assignment_repository.dart
@@ -33,12 +33,14 @@ class AssignmentRepository {
 
     Duration total = Duration.zero;
     for (final e in elements.whereType<TaskElement>()) {
-      if (!e.workerIds.contains(workerId)) continue;
-      final s = e.startDateTime.isBefore(start) ? start : e.startDateTime;
-      final f = e.endDateTime.isAfter(end) ? end : e.endDateTime;
-      final diff = f.difference(s);
-      if (diff.isNegative) continue;
-      total += diff;
+      final matches = e.assignments.where((a) => a.workerId == workerId);
+      for (final a in matches) {
+        final s = a.startDateTime.isBefore(start) ? start : a.startDateTime;
+        final f = a.endDateTime.isAfter(end) ? end : a.endDateTime;
+        final diff = f.difference(s);
+        if (diff.isNegative) continue;
+        total += diff;
+      }
     }
     return total;
   }

--- a/domain/models/grafik/impl/task_element.dart
+++ b/domain/models/grafik/impl/task_element.dart
@@ -5,7 +5,6 @@ import 'task_assignment.dart';
 /// Element zadania, np. przypisanie pracowników do konkretnego zadania.
 class TaskElement extends GrafikElement {
   // ───────── PERSISTOWANE ─────────
-  final List<String> workerIds;
   final String orderId;
   final GrafikStatus status;
   final GrafikTaskType taskType;
@@ -24,7 +23,6 @@ class TaskElement extends GrafikElement {
     required DateTime startDateTime,
     required DateTime endDateTime,
     required String additionalInfo,
-    required this.workerIds,
     required this.orderId,
     required this.status,
     required this.taskType,
@@ -58,7 +56,6 @@ class TaskElement extends GrafikElement {
     DateTime? startDateTime,
     DateTime? endDateTime,
     String? additionalInfo,
-    List<String>? workerIds,
     List<TaskAssignment>? assignments,
     String? orderId,
     GrafikStatus? status,
@@ -75,7 +72,6 @@ class TaskElement extends GrafikElement {
       startDateTime: startDateTime ?? this.startDateTime,
       endDateTime: endDateTime ?? this.endDateTime,
       additionalInfo: additionalInfo ?? this.additionalInfo,
-      workerIds: workerIds ?? List<String>.from(this.workerIds),
       orderId: orderId ?? this.orderId,
       status: status ?? this.status,
       taskType: taskType ?? this.taskType,
@@ -97,7 +93,6 @@ class TaskElement extends GrafikElement {
     startDateTime: startDateTime,
     endDateTime: endDateTime,
     additionalInfo: additionalInfo,
-    workerIds: List<String>.from(workerIds),
     orderId: orderId,
     status: status,
     taskType: taskType,

--- a/domain/models/grafik/impl/task_planning_to_task_extension.dart
+++ b/domain/models/grafik/impl/task_planning_to_task_extension.dart
@@ -14,17 +14,25 @@ extension ToTaskElement on TaskPlanningElement {
       Duration(minutes: durationMinutes ?? minutes),
     );
 
+    final ids = overrideWorkerIds ?? workerIds;
+    final assigns = ids
+        .map((id) => TaskAssignment(
+              workerId: id,
+              startDateTime: s,
+              endDateTime: e,
+            ))
+        .toList();
+
     return TaskElement(
       id: '',
       startDateTime: s,
       endDateTime: e,
       additionalInfo: additionalInfo,
-      workerIds: overrideWorkerIds ?? workerIds,
       orderId: orderId,
       status: GrafikStatus.Realizacja,
       taskType: taskType,
       carIds: const [],
-      assignments: const [],
+      assignments: assigns,
       addedByUserId: addedByUserId,
       addedTimestamp: DateTime.now(),
       closed: false,

--- a/domain/models/grafik/impl/task_template.dart
+++ b/domain/models/grafik/impl/task_template.dart
@@ -10,7 +10,6 @@ class TaskTemplate {
   final GrafikTaskType taskType;
   final GrafikStatus status;
   final String orderId;
-  final List<String> workerIds;
   final List<String> carIds;
   final int startHour;
   final int endHour;
@@ -21,7 +20,6 @@ class TaskTemplate {
     required this.taskType,
     required this.status,
     required this.orderId,
-    required this.workerIds,
     required this.carIds,
     required this.startHour,
     required this.endHour,
@@ -36,7 +34,6 @@ const kTaskTemplates = <TaskTemplate>[
     taskType: GrafikTaskType.Inne,
     status: GrafikStatus.Realizacja,
     orderId: '0001',
-    workerIds: ['6pwokcelgwbT7wAvEuo8'],
     carIds: [],
     startHour: 7,
     endHour: 15,
@@ -47,7 +44,6 @@ const kTaskTemplates = <TaskTemplate>[
     taskType: GrafikTaskType.Inne,
     status: GrafikStatus.Realizacja,
     orderId: '0001',
-    workerIds: ['FTuK6LFO6qt0apMTSGWi'],
     carIds: ['QqYtL81vjbmpi6859Q9Y'],
     startHour: 7,
     endHour: 15,

--- a/feature/grafik/cubit/grafik_mapping_utils.dart
+++ b/feature/grafik/cubit/grafik_mapping_utils.dart
@@ -28,7 +28,8 @@ Map<String, List<String>> calculateTaskTimeIssueDisplayMapping({
       if (overlapDuration.inMinutes <= 0) continue;
 
       final workerId = issue.workerId;
-      if (!task.workerIds.contains(workerId)) continue;
+      final assignedIds = task.assignments.map((a) => a.workerId).toSet();
+      if (!assignedIds.contains(workerId)) continue;
 
       try {
         final employee = employees.firstWhere((e) => e.uid == workerId);

--- a/feature/grafik/form/standard_task_row.dart
+++ b/feature/grafik/form/standard_task_row.dart
@@ -17,12 +17,12 @@ class StandardTaskRow extends StatelessWidget {
     final employees = context.watch<GrafikCubit>().state.employees;
 
     final List<Widget> taskWidgets = standardTasks.map((task) {
+      final assignedIds = task.assignments.map((a) => a.workerId).toList();
       List<String> workerSurnames;
-      if (task.workerIds.isEmpty) {
-        // Jeśli nie ma przypisanych workerIds, ustawiamy fallback.
+      if (assignedIds.isEmpty) {
         workerSurnames = ["Brak przypisanych pracowników"];
       } else {
-        workerSurnames = task.workerIds.map((workerId) {
+        workerSurnames = assignedIds.map((workerId) {
           try {
             final employee = employees.firstWhere((e) => e.uid == workerId);
             final surname = employee.fullName.split(' ').first;

--- a/feature/grafik/form/strategy/task_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_element_strategy.dart
@@ -21,7 +21,6 @@ class TaskElementStrategy implements GrafikElementFormStrategy {
       startDateTime: start,
       endDateTime: end,
       additionalInfo: '',
-      workerIds: const [],
       orderId: '',
       status: GrafikStatus.Realizacja,
       taskType: GrafikTaskType.Inne,

--- a/feature/grafik/form/task_element_fields.dart
+++ b/feature/grafik/form/task_element_fields.dart
@@ -6,6 +6,7 @@ import 'package:kabast/theme/app_tokens.dart';
 
 import '../../../domain/models/grafik/enums.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
+import '../../../domain/models/grafik/impl/task_assignment.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
 import '../../employee/employee_picker.dart';
@@ -20,7 +21,8 @@ class TaskFields extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final missing = (element.expectedWorkerCount ?? 0) - element.workerIds.length;
+    final assignedIds = element.assignments.map((a) => a.workerId).toList();
+    final missing = (element.expectedWorkerCount ?? 0) - assignedIds.length;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -64,10 +66,18 @@ class TaskFields extends StatelessWidget {
 
         EmployeePicker(
           employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
-          initialSelectedIds: element.workerIds,
+          initialSelectedIds: assignedIds,
           onSelectionChanged: (selectedEmployees) {
             final ids = selectedEmployees.map((e) => e.uid).toList();
-            context.read<GrafikElementFormCubit>().updateField('workerIds', ids);
+            final assigns = ids
+                .map((id) => TaskAssignment(
+                      workerId: id,
+                      startDateTime: element.startDateTime,
+                      endDateTime: element.endDateTime,
+                    ))
+                .toList();
+            context.read<GrafikElementFormCubit>()
+                .updateField('assignments', assigns);
           },
         ),
         const SizedBox(height: AppSpacing.sm * 2),

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -183,7 +183,8 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
 
   List<Widget> _buildTaskElementDetails(TaskElement task) => [
     const Text('Pracownicy:'),
-    EmployeeList(employeeIds: task.workerIds),
+    EmployeeList(
+        employeeIds: task.assignments.map((a) => a.workerId).toList()),
     const SizedBox(height: 8),
     Text('Order ID: ${task.orderId}'),
     Text('Status: ${task.status.name}'),

--- a/feature/grafik/widget/task/employee_daily_summary.dart
+++ b/feature/grafik/widget/task/employee_daily_summary.dart
@@ -22,22 +22,12 @@ class EmployeeDailySummary extends StatelessWidget {
   Widget build(BuildContext context) {
     final Map<String, List<Map<String, dynamic>>> employeeEntries = {};
     for (final task in tasks) {
-      if (task.assignments.isNotEmpty) {
-        for (final a in task.assignments) {
-          employeeEntries.putIfAbsent(a.workerId, () => []).add({
-            'start': a.startDateTime,
-            'end': a.endDateTime,
-            'orderId': task.orderId,
-          });
-        }
-      } else {
-        for (final workerId in task.workerIds) {
-          employeeEntries.putIfAbsent(workerId, () => []).add({
-            'start': task.startDateTime,
-            'end': task.endDateTime,
-            'orderId': task.orderId,
-          });
-        }
+      for (final a in task.assignments) {
+        employeeEntries.putIfAbsent(a.workerId, () => []).add({
+          'start': a.startDateTime,
+          'end': a.endDateTime,
+          'orderId': task.orderId,
+        });
       }
     }
 

--- a/feature/grafik/widget/task/task_tile.dart
+++ b/feature/grafik/widget/task/task_tile.dart
@@ -34,9 +34,7 @@ class TaskTile extends StatelessWidget {
   Widget build(BuildContext context) {
     // Pobierz dane
     final state      = context.watch<GrafikCubit>().state;
-    final assignedIds = task.assignments.isNotEmpty
-        ? task.assignments.map((a) => a.workerId).toSet()
-        : task.workerIds.toSet();
+    final assignedIds = task.assignments.map((a) => a.workerId).toSet();
     final employees =
         state.employees.where((e) => assignedIds.contains(e.uid));
     final vehicles   = state.vehicles .where((v) => task.carIds.contains(v.id));

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -25,32 +25,24 @@ class TaskWeekTile extends StatelessWidget {
 
   String _buildEmployeeNames(BuildContext context) {
     final state = context.read<GrafikCubit>().state;
-    if (task.assignments.isNotEmpty) {
-      final byWorker = <String, List<TaskAssignment>>{};
-      for (final a in task.assignments) {
-        byWorker.putIfAbsent(a.workerId, () => []).add(a);
-      }
-      return byWorker.entries.map((e) {
-        final emp = state.employees.firstWhere(
-          (em) => em.uid == e.key,
-          orElse: () => null,
-        );
-        final name = emp != null
-            ? _formatEmployeeName(emp.fullName)
-            : e.key;
-        final times = e.value
-            .map((a) => '${a.startDateTime.hour.toString().padLeft(2,'0')}-${a.endDateTime.hour.toString().padLeft(2,'0')}')
-            .join(', ');
-        return '$name $times';
-      }).join(", ");
-    } else {
-      final filteredEmployees = state.employees
-          .where((employee) => task.workerIds.contains(employee.uid))
-          .toList();
-      return filteredEmployees
-          .map((employee) => _formatEmployeeName(employee.fullName))
-          .join(", ");
+    if (task.assignments.isEmpty) return '';
+    final byWorker = <String, List<TaskAssignment>>{};
+    for (final a in task.assignments) {
+      byWorker.putIfAbsent(a.workerId, () => []).add(a);
     }
+    return byWorker.entries.map((e) {
+      final emp = state.employees.firstWhere(
+        (em) => em.uid == e.key,
+        orElse: () => null,
+      );
+      final name = emp != null
+          ? _formatEmployeeName(emp.fullName)
+          : e.key;
+      final times = e.value
+          .map((a) => '${a.startDateTime.hour.toString().padLeft(2,'0')}-${a.endDateTime.hour.toString().padLeft(2,'0')}')
+          .join(', ');
+      return '$name $times';
+    }).join(", ");
   }
 
   String _buildCarDescriptions(BuildContext context, List<String> carIds) {


### PR DESCRIPTION
## Summary
- drop `workerIds` from `TaskElement`
- rely on `assignments` for conversion and DTO mapping
- update task templates and strategies
- refactor forms and widgets to use assignments
- adjust assignment repository and mapping utilities

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f9004ef7c83338a3c37ae421c1d54