### PR TITLE
Fix time issue membership check

### DIFF
--- a/feature/grafik/cubit/grafik_mapping_utils.dart
+++ b/feature/grafik/cubit/grafik_mapping_utils.dart
@@ -28,7 +28,7 @@ Map<String, List<String>> calculateTaskTimeIssueDisplayMapping({
       if (overlapDuration.inMinutes <= 0) continue;
 
       final workerId = issue.workerId;
-      if (!task.workerIds.contains(workerId)) continue;
+      if (!task.assignments.any((a) => a.workerId == workerId)) continue;
 
       try {
         final employee = employees.firstWhere((e) => e.uid == workerId);


### PR DESCRIPTION
## Summary
- fix check for time issue presence in task by verifying assignments rather than workerIds

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9203d8a48333844be20cd1c9946c