### PR TITLE
Switch to assignment-based employee handling

### DIFF
--- a/feature/grafik/form/standard_task_row.dart
+++ b/feature/grafik/form/standard_task_row.dart
@@ -17,12 +17,12 @@ class StandardTaskRow extends StatelessWidget {
     final employees = context.watch<GrafikCubit>().state.employees;
 
     final List<Widget> taskWidgets = standardTasks.map((task) {
+      final assignedIds = task.assignments.map((a) => a.workerId).toSet();
       List<String> workerSurnames;
-      if (task.workerIds.isEmpty) {
-        // Jeśli nie ma przypisanych workerIds, ustawiamy fallback.
+      if (assignedIds.isEmpty) {
         workerSurnames = ["Brak przypisanych pracowników"];
       } else {
-        workerSurnames = task.workerIds.map((workerId) {
+        workerSurnames = assignedIds.map((workerId) {
           try {
             final employee = employees.firstWhere((e) => e.uid == workerId);
             final surname = employee.fullName.split(' ').first;

--- a/feature/grafik/form/task_element_fields.dart
+++ b/feature/grafik/form/task_element_fields.dart
@@ -6,6 +6,7 @@ import 'package:kabast/theme/app_tokens.dart';
 
 import '../../../domain/models/grafik/enums.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
+import '../../../domain/models/grafik/impl/task_assignment.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
 import '../../employee/employee_picker.dart';
@@ -20,7 +21,9 @@ class TaskFields extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final missing = (element.expectedWorkerCount ?? 0) - element.workerIds.length;
+    final assignedCount =
+        element.assignments.map((a) => a.workerId).toSet().length;
+    final missing = (element.expectedWorkerCount ?? 0) - assignedCount;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -64,10 +67,19 @@ class TaskFields extends StatelessWidget {
 
         EmployeePicker(
           employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
-          initialSelectedIds: element.workerIds,
+          initialSelectedIds:
+              element.assignments.map((a) => a.workerId).toList(),
           onSelectionChanged: (selectedEmployees) {
-            final ids = selectedEmployees.map((e) => e.uid).toList();
-            context.read<GrafikElementFormCubit>().updateField('workerIds', ids);
+            final assignments = selectedEmployees
+                .map((e) => TaskAssignment(
+                      workerId: e.uid,
+                      startDateTime: element.startDateTime,
+                      endDateTime: element.endDateTime,
+                    ))
+                .toList();
+            context
+                .read<GrafikElementFormCubit>()
+                .updateField('assignments', assignments);
           },
         ),
         const SizedBox(height: AppSpacing.sm * 2),

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -15,7 +15,7 @@ import 'package:kabast/feature/permission/permission_widget.dart';
 import 'package:kabast/injection.dart';
 
 import '../../cubit/grafik_cubit.dart';
-import '../task/employee_list.dart';
+import '../task/assignment_list.dart';
 import '../task/vehicle_list.dart';
 
 Future<void> showGrafikElementPopup(
@@ -183,7 +183,10 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
 
   List<Widget> _buildTaskElementDetails(TaskElement task) => [
     const Text('Pracownicy:'),
-    EmployeeList(employeeIds: task.workerIds),
+    if (task.assignments.isNotEmpty)
+      AssignmentList(assignments: task.assignments)
+    else
+      const Text('Brak przypisanych pracowników'),
     const SizedBox(height: 8),
     Text('Order ID: ${task.orderId}'),
     Text('Status: ${task.status.name}'),

--- a/feature/grafik/widget/task/employee_daily_summary.dart
+++ b/feature/grafik/widget/task/employee_daily_summary.dart
@@ -22,22 +22,12 @@ class EmployeeDailySummary extends StatelessWidget {
   Widget build(BuildContext context) {
     final Map<String, List<Map<String, dynamic>>> employeeEntries = {};
     for (final task in tasks) {
-      if (task.assignments.isNotEmpty) {
-        for (final a in task.assignments) {
-          employeeEntries.putIfAbsent(a.workerId, () => []).add({
-            'start': a.startDateTime,
-            'end': a.endDateTime,
-            'orderId': task.orderId,
-          });
-        }
-      } else {
-        for (final workerId in task.workerIds) {
-          employeeEntries.putIfAbsent(workerId, () => []).add({
-            'start': task.startDateTime,
-            'end': task.endDateTime,
-            'orderId': task.orderId,
-          });
-        }
+      for (final a in task.assignments) {
+        employeeEntries.putIfAbsent(a.workerId, () => []).add({
+          'start': a.startDateTime,
+          'end': a.endDateTime,
+          'orderId': task.orderId,
+        });
       }
     }
 

--- a/feature/grafik/widget/task/task_header.dart
+++ b/feature/grafik/widget/task/task_header.dart
@@ -22,31 +22,31 @@ class TaskHeader extends StatelessWidget {
     String fmt(DateTime dt) =>
         '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
     Widget _timeWidget() {
-      if (task.assignments.isNotEmpty) {
-        final state = context.read<GrafikCubit>().state;
-        final byWorker = <String, List<TaskAssignment>>{};
-        for (final a in task.assignments) {
-          byWorker.putIfAbsent(a.workerId, () => []).add(a);
-        }
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: byWorker.entries.map((e) {
-            final emp = state.employees.firstWhere(
-              (el) => el.uid == e.key,
-              orElse: () => null,
-            );
-            final name = emp?.formattedNameWithSecondInitial ?? e.key;
-            final times = e.value
-                .map((a) => '${fmt(a.startDateTime)}-${fmt(a.endDateTime)}')
-                .join(', ');
-            return Text('$name $times',
-                style: Theme.of(context).textTheme.bodyMedium);
-          }).toList(),
+      final state = context.read<GrafikCubit>().state;
+      final byWorker = <String, List<TaskAssignment>>{};
+      for (final a in task.assignments) {
+        byWorker.putIfAbsent(a.workerId, () => []).add(a);
+      }
+      if (byWorker.isEmpty) {
+        return Text(
+          'Brak przypisanych pracowników',
+          style: Theme.of(context).textTheme.bodyMedium,
         );
       }
-      return Text(
-        '${fmt(task.startDateTime)}–${fmt(task.endDateTime)}',
-        style: Theme.of(context).textTheme.bodyMedium,
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: byWorker.entries.map((e) {
+          final emp = state.employees.firstWhere(
+            (el) => el.uid == e.key,
+            orElse: () => null,
+          );
+          final name = emp?.formattedNameWithSecondInitial ?? e.key;
+          final times = e.value
+              .map((a) => '${fmt(a.startDateTime)}-${fmt(a.endDateTime)}')
+              .join(', ');
+          return Text('$name $times',
+              style: Theme.of(context).textTheme.bodyMedium);
+        }).toList(),
       );
     }
 

--- a/feature/grafik/widget/task/task_tile.dart
+++ b/feature/grafik/widget/task/task_tile.dart
@@ -34,9 +34,7 @@ class TaskTile extends StatelessWidget {
   Widget build(BuildContext context) {
     // Pobierz dane
     final state      = context.watch<GrafikCubit>().state;
-    final assignedIds = task.assignments.isNotEmpty
-        ? task.assignments.map((a) => a.workerId).toSet()
-        : task.workerIds.toSet();
+    final assignedIds = task.assignments.map((a) => a.workerId).toSet();
     final employees =
         state.employees.where((e) => assignedIds.contains(e.uid));
     final vehicles   = state.vehicles .where((v) => task.carIds.contains(v.id));
@@ -66,6 +64,14 @@ class TaskTile extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
                 child: AssignmentList(assignments: task.assignments),
+              )
+            else
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                child: Text(
+                  'Brak przypisanych pracowników',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
               ),
             EmployeeChipList(employees: employees),
             if (vehicles.isNotEmpty)

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -25,32 +25,26 @@ class TaskWeekTile extends StatelessWidget {
 
   String _buildEmployeeNames(BuildContext context) {
     final state = context.read<GrafikCubit>().state;
-    if (task.assignments.isNotEmpty) {
-      final byWorker = <String, List<TaskAssignment>>{};
-      for (final a in task.assignments) {
-        byWorker.putIfAbsent(a.workerId, () => []).add(a);
-      }
-      return byWorker.entries.map((e) {
-        final emp = state.employees.firstWhere(
-          (em) => em.uid == e.key,
-          orElse: () => null,
-        );
-        final name = emp != null
-            ? _formatEmployeeName(emp.fullName)
-            : e.key;
-        final times = e.value
-            .map((a) => '${a.startDateTime.hour.toString().padLeft(2,'0')}-${a.endDateTime.hour.toString().padLeft(2,'0')}')
-            .join(', ');
-        return '$name $times';
-      }).join(", ");
-    } else {
-      final filteredEmployees = state.employees
-          .where((employee) => task.workerIds.contains(employee.uid))
-          .toList();
-      return filteredEmployees
-          .map((employee) => _formatEmployeeName(employee.fullName))
-          .join(", ");
+    final byWorker = <String, List<TaskAssignment>>{};
+    for (final a in task.assignments) {
+      byWorker.putIfAbsent(a.workerId, () => []).add(a);
     }
+    if (byWorker.isEmpty) {
+      return "Brak przypisanych pracowników";
+    }
+    return byWorker.entries.map((e) {
+      final emp = state.employees.firstWhere(
+        (em) => em.uid == e.key,
+        orElse: () => null,
+      );
+      final name = emp != null
+          ? _formatEmployeeName(emp.fullName)
+          : e.key;
+      final times = e.value
+          .map((a) => '${a.startDateTime.hour.toString().padLeft(2,'0')}-${a.endDateTime.hour.toString().padLeft(2,'0')}')
+          .join(', ');
+      return '$name $times';
+    }).join(", ");
   }
 
   String _buildCarDescriptions(BuildContext context, List<String> carIds) {


### PR DESCRIPTION
## Summary
- update TaskFields to manage `assignments`
- show assignments in `StandardTaskRow`, `TaskWeekTile`, `TaskTile`, and popups
- drop `workerIds` fallback across task widgets
- adjust `EmployeeDailySummary` calculations

## Testing
- `dart format -o none .` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9204445c8333a19dbd6d161837aa