### PR TITLE
Fix task assignment dto import

### DIFF
--- a/data/dto/grafik/task_assignment_dto.dart
+++ b/data/dto/grafik/task_assignment_dto.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import '../../../domain/models/grafik/impl/task_assignment.dart';
+import '../../../domain/models/grafik/task_assignment.dart';
 
 class TaskAssignmentDto {
   final String taskId;


### PR DESCRIPTION
## Summary
- fix import for `TaskAssignmentDto`
- ensure `taskId` is included when mapping to/from domain

## Testing
- `dart analyze data/dto/grafik/task_assignment_dto.dart` *(fails: Target of URI doesn't exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686f9201b2e8833383d6a020114c75e7