### PR TITLE
Add Firestore V2 service

### DIFF
--- a/data/services/grafik_element_firebase_service_v2.dart
+++ b/data/services/grafik_element_firebase_service_v2.dart
@@ -1,0 +1,137 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:rxdart/rxdart.dart';
+import '../../domain/models/grafik/enums.dart';
+import '../../domain/models/grafik/grafik_element.dart';
+import '../dto/grafik/grafik_element_dto.dart';
+import '../../domain/services/i_grafik_element_service.dart';
+
+/// Firestore service using the `task_elements_v2` collection.
+///
+/// Works the same way as [GrafikElementFirebaseService] but stores data
+/// separately so the new TaskAssignment model doesn't clash with the old
+/// `task_elements_v2` documents.
+class GrafikElementFirebaseServiceV2 implements IGrafikElementService {
+  final FirebaseFirestore _firestore;
+
+  GrafikElementFirebaseServiceV2(this._firestore);
+
+  @override
+  String generateNewTaskId() {
+    return _firestore.collection('task_elements_v2').doc().id;
+  }
+
+  // ───────────────────────────────────────────────────────────
+  //  1.  Dotychczasowe zapytanie zakresem                 ════
+  // ───────────────────────────────────────────────────────────
+  Stream<List<GrafikElement>> getGrafikElementsWithinRange({
+    required DateTime start,
+    required DateTime end,
+    List<String>? types,
+  }) {
+    var query = _firestore
+        .collection('task_elements_v2')
+        .where('startDateTime', isLessThanOrEqualTo: Timestamp.fromDate(end))
+        .where(
+          'endDateTime',
+          isGreaterThanOrEqualTo: Timestamp.fromDate(start),
+        );
+
+    if (types != null && types.isNotEmpty) {
+      query = query.where('type', whereIn: types);
+    }
+
+    return query.snapshots().map((snapshot) {
+      return snapshot.docs.map((doc) {
+        final dto = GrafikElementDto.fromFirestore(doc);
+        return dto.toDomain();
+      }).toList();
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────
+  //  2.  Wszystkie TaskPlanningElement z  isPending == true  ══
+  // ───────────────────────────────────────────────────────────
+  Stream<List<GrafikElement>> getPendingTaskPlannings() {
+    final q = _firestore
+        .collection('task_elements_v2')
+        .where('type', isEqualTo: 'TaskPlanningElement')
+        .where('isPending', isEqualTo: true);
+
+    return q.snapshots().map(
+      (snap) =>
+          snap.docs.map((doc) {
+            final dto = GrafikElementDto.fromFirestore(doc);
+            return dto.toDomain();
+          }).toList(),
+    );
+  }
+
+  // ───────────────────────────────────────────────────────────
+  //  3.  Zakres  +  „wisi‑grozi”  w jednym strumieniu      ════
+  // ───────────────────────────────────────────────────────────
+  Stream<List<GrafikElement>> getGrafikElementsWithinRangeIncludingPending({
+    required DateTime start,
+    required DateTime end,
+    List<String>? types,
+  }) {
+    final range$ = getGrafikElementsWithinRange(
+      start: start,
+      end: end,
+      types: types,
+    );
+
+    // pendingy dokładamy tylko gdy filtr obejmuje TaskPlanningElement
+    final needPending = types == null || types.contains('TaskPlanningElement');
+    if (!needPending) return range$;
+
+    final pending$ = getPendingTaskPlannings();
+
+    return Rx.combineLatest2<
+      List<GrafikElement>,
+      List<GrafikElement>,
+      List<GrafikElement>
+    >(range$, pending$, (range, pending) {
+      final byId = {
+        for (final e in [...range, ...pending]) e.id: e,
+      };
+      return byId.values.toList();
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────
+  //  CRUD – bez zmian
+  // ───────────────────────────────────────────────────────────
+
+  Future<void> upsertGrafikElement(GrafikElement element) async {
+    final dto = GrafikElementDto.fromDomain(element);
+    final data = dto.toJson();
+    if (element.id.isEmpty) {
+      final docRef = await _firestore.collection('task_elements_v2').add(data);
+      await docRef.update({'id': docRef.id});
+    } else {
+      await _firestore.collection('task_elements_v2').doc(element.id).set(data);
+    }
+  }
+
+  Future<void> updateGrafikElementField(String id, Map<String, dynamic> data) =>
+      _firestore.collection('task_elements_v2').doc(id).update(data);
+
+  Future<void> updateTaskStatus(String id, GrafikStatus status) =>
+      updateGrafikElementField(id, {'status': status.toString()});
+
+  Future<void> upsertManyGrafikElements(List<GrafikElement> elements) async {
+    final batch = _firestore.batch();
+    final col = _firestore.collection('task_elements_v2');
+
+    for (final e in elements) {
+      final ref = col.doc();
+      final dto = GrafikElementDto.fromDomain(e);
+      final data = dto.toJson()..['id'] = ref.id;
+      batch.set(ref, data);
+    }
+    await batch.commit();
+  }
+
+  Future<void> deleteGrafikElement(String id) =>
+      _firestore.collection('task_elements_v2').doc(id).delete();
+}

--- a/injection.dart
+++ b/injection.dart
@@ -22,6 +22,7 @@ import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service.dart';
+import 'package:kabast/data/services/grafik_element_firebase_service_v2.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
 
 import 'package:kabast/data/services/assignment_firebase_service.dart';
@@ -53,6 +54,11 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<IGrafikElementService>(
     () => GrafikElementFirebaseService(getIt<FirebaseFirestore>()),
+  );
+  // New Firestore service for task_elements_v2
+  getIt.registerLazySingleton<IGrafikElementService>(
+    () => GrafikElementFirebaseServiceV2(getIt<FirebaseFirestore>()),
+    instanceName: 'v2',
   );
   getIt.registerLazySingleton<IAssignmentService>(
     () => AssignmentFirebaseService(getIt<FirebaseFirestore>()),

--- a/main.dart
+++ b/main.dart
@@ -9,6 +9,8 @@ import 'injection.dart';
 import 'feature/auth/auth_cubit.dart';
 import 'feature/grafik/cubit/grafik_cubit.dart';
 import 'feature/date/date_cubit.dart';
+import 'data/repositories/grafik_element_repository.dart';
+import 'domain/services/i_grafik_element_service.dart';
 import 'app_router.dart';
 import 'theme/theme.dart';
 
@@ -32,6 +34,21 @@ Future<void> main() async {
       .then((duration) {
         print('Demo worker time last week: ${duration.inHours}h');
         exampleCubit.close();
+      });
+
+  // Demonstrate usage of the new V2 Firestore service
+  final v2Repo = GrafikElementRepository(
+    GetIt.instance<IGrafikElementService>(instanceName: 'v2'),
+  );
+  v2Repo
+      .getElementsWithinRange(
+        start: now.subtract(const Duration(days: 1)),
+        end: now,
+        types: ['TaskElement'],
+      )
+      .first
+      .then((elements) {
+        print('V2 elements count: ${elements.length}');
       });
   runApp(const MyApp());
 }


### PR DESCRIPTION
## Summary
- support a new Firestore collection `task_elements_v2`
- register `GrafikElementFirebaseServiceV2` in dependency injection
- show usage of the V2 service in `main.dart`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f999440f48333a8f9e1933e42ad1b