### PR TITLE
Switch to V2 Grafik element service

### DIFF
--- a/injection.dart
+++ b/injection.dart
@@ -21,7 +21,6 @@ import 'package:kabast/feature/auth/auth_cubit.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
-import 'package:kabast/data/services/grafik_element_firebase_service.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service_v2.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
 
@@ -52,10 +51,11 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<IVehicleService>(
     () => VehicleFirebaseService(getIt<FirebaseFirestore>()),
   );
+  // Use the V2 Firestore service by default
   getIt.registerLazySingleton<IGrafikElementService>(
-    () => GrafikElementFirebaseService(getIt<FirebaseFirestore>()),
+    () => GrafikElementFirebaseServiceV2(getIt<FirebaseFirestore>()),
   );
-  // New Firestore service for task_elements_v2
+  // Named instance kept for backward compatibility
   getIt.registerLazySingleton<IGrafikElementService>(
     () => GrafikElementFirebaseServiceV2(getIt<FirebaseFirestore>()),
     instanceName: 'v2',

--- a/main.dart
+++ b/main.dart
@@ -36,9 +36,9 @@ Future<void> main() async {
         exampleCubit.close();
       });
 
-  // Demonstrate usage of the new V2 Firestore service
+  // Demonstrate usage of the Firestore service (now defaulting to V2)
   final v2Repo = GrafikElementRepository(
-    GetIt.instance<IGrafikElementService>(instanceName: 'v2'),
+    GetIt.instance<IGrafikElementService>(),
   );
   v2Repo
       .getElementsWithinRange(


### PR DESCRIPTION
## Summary
- default `IGrafikElementService` to `GrafikElementFirebaseServiceV2`
- remove registration for the old service
- update example in `main.dart` to use the default service

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa5cd45cc8333824decd01f0fb8e9