### PR TITLE
Remove embedded assignments from TaskElement

### DIFF
--- a/data/dto/grafik/task_element_dto.dart
+++ b/data/dto/grafik/task_element_dto.dart
@@ -3,14 +3,12 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
 import '../../../domain/models/grafik/enums.dart';
 import 'grafik_element_dto.dart';
-import 'task_assignment_dto.dart';
 
 class TaskElementDto extends GrafikElementDto {
   final String orderId;
   final GrafikStatus status;
   final GrafikTaskType taskType;
   final List<String> carIds;
-  final List<TaskAssignmentDto> assignments;
 
   TaskElementDto({
     required super.id,
@@ -25,7 +23,6 @@ class TaskElementDto extends GrafikElementDto {
     required this.status,
     required this.taskType,
     required this.carIds,
-    this.assignments = const [],
   });
 
   factory TaskElementDto.fromJson(Map<String, dynamic> json) {
@@ -57,11 +54,6 @@ class TaskElementDto extends GrafikElementDto {
         orElse: () => GrafikTaskType.Inne,
       ),
       carIds: (json['carIds'] as List?)?.cast<String>() ?? <String>[],
-      assignments: (json['assignments'] as List?)
-              ?.map((e) => TaskAssignmentDto.fromJson(
-                  Map<String, dynamic>.from(e as Map)))
-              .toList() ??
-          <TaskAssignmentDto>[],
     );
   }
 
@@ -71,7 +63,6 @@ class TaskElementDto extends GrafikElementDto {
         'status': status.toString(),
         'taskType': taskType.toString(),
         'carIds': carIds,
-        'assignments': assignments.map((a) => a.toJson()).toList(),
       };
 
   TaskElement toDomain() => TaskElement(
@@ -83,7 +74,6 @@ class TaskElementDto extends GrafikElementDto {
         status: status,
         taskType: taskType,
         carIds: carIds,
-        assignments: assignments.map((a) => a.toDomain()).toList(),
         addedByUserId: addedByUserId,
         addedTimestamp: addedTimestamp,
         closed: closed,
@@ -102,8 +92,5 @@ class TaskElementDto extends GrafikElementDto {
         status: element.status,
         taskType: element.taskType,
         carIds: List<String>.from(element.carIds),
-        assignments: element.assignments
-            .map((a) => TaskAssignmentDto.fromDomain(a))
-            .toList(),
       );
 }

--- a/domain/models/grafik/impl/task_element.dart
+++ b/domain/models/grafik/impl/task_element.dart
@@ -1,6 +1,5 @@
 import '../enums.dart';
 import '../grafik_element.dart';
-import 'task_assignment.dart';
 
 /// Element zadania, np. przypisanie pracowników do konkretnego zadania.
 class TaskElement extends GrafikElement {
@@ -9,7 +8,6 @@ class TaskElement extends GrafikElement {
   final GrafikStatus status;
   final GrafikTaskType taskType;
   final List<String> carIds;
-  final List<TaskAssignment> assignments;
 
   // ───────── TYLKO DO WIDOKU ─────────
   /// Ilu pracowników pierwotnie planowano (przy konwersji z TaskPlanningElement).
@@ -27,7 +25,6 @@ class TaskElement extends GrafikElement {
     required this.status,
     required this.taskType,
     required this.carIds,
-    this.assignments = const [],
     required String addedByUserId,
     required DateTime addedTimestamp,
     required bool closed,
@@ -56,7 +53,6 @@ class TaskElement extends GrafikElement {
     DateTime? startDateTime,
     DateTime? endDateTime,
     String? additionalInfo,
-    List<TaskAssignment>? assignments,
     String? orderId,
     GrafikStatus? status,
     GrafikTaskType? taskType,
@@ -76,7 +72,6 @@ class TaskElement extends GrafikElement {
       status: status ?? this.status,
       taskType: taskType ?? this.taskType,
       carIds: carIds ?? List<String>.from(this.carIds),
-      assignments: assignments ?? List<TaskAssignment>.from(this.assignments),
       addedByUserId: addedByUserId ?? this.addedByUserId,
       addedTimestamp: addedTimestamp ?? this.addedTimestamp,
       closed: closed ?? this.closed,
@@ -97,7 +92,6 @@ class TaskElement extends GrafikElement {
     status: status,
     taskType: taskType,
     carIds: List<String>.from(carIds),
-    assignments: List<TaskAssignment>.from(assignments),
     addedByUserId: addedByUserId,
     addedTimestamp: addedTimestamp,
     closed: closed,

--- a/domain/models/grafik/impl/task_planning_to_task_extension.dart
+++ b/domain/models/grafik/impl/task_planning_to_task_extension.dart
@@ -14,14 +14,6 @@ extension ToTaskElement on TaskPlanningElement {
       Duration(minutes: durationMinutes ?? minutes),
     );
 
-    final ids = overrideWorkerIds ?? workerIds;
-    final assigns = ids
-        .map((id) => TaskAssignment(
-              workerId: id,
-              startDateTime: s,
-              endDateTime: e,
-            ))
-        .toList();
 
     return TaskElement(
       id: '',
@@ -32,7 +24,6 @@ extension ToTaskElement on TaskPlanningElement {
       status: GrafikStatus.Realizacja,
       taskType: taskType,
       carIds: const [],
-      assignments: assigns,
       addedByUserId: addedByUserId,
       addedTimestamp: DateTime.now(),
       closed: false,

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -95,6 +95,7 @@ class GrafikCubit extends Cubit<GrafikState> {
           tasks: tasks,
           issues: issues,
           employees: employees,
+          assignments: assignments,
         );
 
         final transferMapping = calculateTaskTransferDisplayMapping(

--- a/feature/grafik/cubit/grafik_mapping_utils.dart
+++ b/feature/grafik/cubit/grafik_mapping_utils.dart
@@ -8,11 +8,15 @@ Map<String, List<String>> calculateTaskTimeIssueDisplayMapping({
   required List<TaskElement> tasks,
   required List<TimeIssueElement> issues,
   required List<Employee> employees,
+  required List<Assignment> assignments,
 }) {
   final mapping = <String, List<String>>{};
 
   for (var task in tasks) {
     final displayStrings = <String>[];
+
+    final taskAssignments =
+        assignments.where((a) => a.taskId == task.id).toList();
 
     for (var issue in issues) {
       final overlapStart = max(
@@ -27,7 +31,7 @@ Map<String, List<String>> calculateTaskTimeIssueDisplayMapping({
       if (overlapDuration.inMinutes <= 0) continue;
 
       final workerId = issue.workerId;
-      final assignedIds = task.assignments.map((a) => a.workerId).toSet();
+      final assignedIds = taskAssignments.map((a) => a.workerId).toSet();
       if (!assignedIds.contains(workerId)) continue;
 
       try {

--- a/feature/grafik/form/standard_task_row.dart
+++ b/feature/grafik/form/standard_task_row.dart
@@ -16,8 +16,13 @@ class StandardTaskRow extends StatelessWidget {
     // Pobieramy listę pracowników, aby odczytać nazwiska.
     final employees = context.watch<GrafikCubit>().state.employees;
 
+    final state = context.watch<GrafikCubit>().state;
+
     final List<Widget> taskWidgets = standardTasks.map((task) {
-      final assignedIds = task.assignments.map((a) => a.workerId).toSet();
+      final assignedIds = state.assignments
+          .where((a) => a.taskId == task.id)
+          .map((a) => a.workerId)
+          .toSet();
       List<String> workerSurnames;
       if (assignedIds.isEmpty) {
         workerSurnames = ["Brak przypisanych pracowników"];

--- a/feature/grafik/form/strategy/task_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_element_strategy.dart
@@ -25,7 +25,6 @@ class TaskElementStrategy implements GrafikElementFormStrategy {
       status: GrafikStatus.Realizacja,
       taskType: GrafikTaskType.Inne,
       carIds: const [],
-      assignments: const [],
       addedByUserId: '',
       addedTimestamp: DateTime.now(),
       closed: false,

--- a/feature/grafik/form/task_element_fields.dart
+++ b/feature/grafik/form/task_element_fields.dart
@@ -6,13 +6,10 @@ import 'package:kabast/theme/app_tokens.dart';
 
 import '../../../domain/models/grafik/enums.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
-import '../../../domain/models/grafik/impl/task_assignment.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
-import '../../employee/employee_picker.dart';
 import '../../vehicle/widget/vehicle_picker.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
-import '../../../../data/repositories/employee_repository.dart';
 import '../../../../data/repositories/vehicle_repository.dart';
 
 class TaskFields extends StatelessWidget {
@@ -21,9 +18,6 @@ class TaskFields extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final assignedCount =
-        element.assignments.map((a) => a.workerId).toSet().length;
-    final missing = (element.expectedWorkerCount ?? 0) - assignedCount;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -31,8 +25,7 @@ class TaskFields extends StatelessWidget {
         // ───── info z planu ─────
         if (element.expectedWorkerCount != null) ...[
           Text(
-            'Planowano: ${element.expectedWorkerCount} pracowników '
-                '(${missing > 0 ? "brakuje $missing" : "obsada pełna"})',
+            'Planowano: ${element.expectedWorkerCount} pracowników',
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
@@ -62,25 +55,6 @@ class TaskFields extends StatelessWidget {
           initialValue: element.taskType,
           onChanged: (val) => context.read<GrafikElementFormCubit>()
               .updateField('taskType', val.toString()),
-        ),
-        const SizedBox(height: AppSpacing.sm * 2),
-
-        EmployeePicker(
-          employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
-          initialSelectedIds:
-              element.assignments.map((a) => a.workerId).toList(),
-          onSelectionChanged: (selectedEmployees) {
-            final assignments = selectedEmployees
-                .map((e) => TaskAssignment(
-                      workerId: e.uid,
-                      startDateTime: element.startDateTime,
-                      endDateTime: element.endDateTime,
-                    ))
-                .toList();
-            context
-                .read<GrafikElementFormCubit>()
-                .updateField('assignments', assignments);
-          },
         ),
         const SizedBox(height: AppSpacing.sm * 2),
         VehiclePicker(

--- a/feature/grafik/widget/task/employee_daily_summary.dart
+++ b/feature/grafik/widget/task/employee_daily_summary.dart
@@ -5,30 +5,48 @@ import '../../../../domain/models/employee.dart';
 import '../../../../domain/models/grafik/impl/task_element.dart';
 import '../../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../../theme/app_tokens.dart';
+import '../../../../domain/models/grafik/assignment.dart';
+import '../../../../domain/models/grafik/enums.dart';
 
 class EmployeeDailySummary extends StatelessWidget {
   final List<TaskElement> tasks;
   final List<Employee> employees;
   final List<TimeIssueElement> timeIssues;
+  final List<Assignment> assignments;
 
   const EmployeeDailySummary({
     super.key,
     required this.tasks,
     required this.employees,
     required this.timeIssues,
+    required this.assignments,
   });
 
   @override
   Widget build(BuildContext context) {
     final Map<String, List<Map<String, dynamic>>> employeeEntries = {};
-    for (final task in tasks) {
-      for (final a in task.assignments) {
-        employeeEntries.putIfAbsent(a.workerId, () => []).add({
-          'start': a.startDateTime,
-          'end': a.endDateTime,
-          'orderId': task.orderId,
-        });
-      }
+    for (final a in assignments) {
+      final task = tasks.firstWhere(
+        (t) => t.id == a.taskId,
+        orElse: () => TaskElement(
+          id: a.taskId,
+          startDateTime: a.startDateTime,
+          endDateTime: a.endDateTime,
+          additionalInfo: '',
+          orderId: '',
+          status: GrafikStatus.Realizacja,
+          taskType: GrafikTaskType.Inne,
+          carIds: const [],
+          addedByUserId: '',
+          addedTimestamp: DateTime.now(),
+          closed: false,
+        ),
+      );
+      employeeEntries.putIfAbsent(a.workerId, () => []).add({
+        'start': a.startDateTime,
+        'end': a.endDateTime,
+        'orderId': task.orderId,
+      });
     }
 
     final Map<String, List<TimeIssueElement>> employeeIssues = {};

--- a/feature/grafik/widget/task/task_header.dart
+++ b/feature/grafik/widget/task/task_header.dart
@@ -3,7 +3,7 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../cubit/grafik_cubit.dart';
-import 'package:kabast/domain/models/grafik/impl/task_assignment.dart';
+import 'package:kabast/domain/models/grafik/assignment.dart';
 
 class TaskHeader extends StatelessWidget {
   final TaskElement task;
@@ -23,8 +23,8 @@ class TaskHeader extends StatelessWidget {
         '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
     Widget _timeWidget() {
       final state = context.read<GrafikCubit>().state;
-      final byWorker = <String, List<TaskAssignment>>{};
-      for (final a in task.assignments) {
+      final byWorker = <String, List<Assignment>>{};
+      for (final a in state.assignments.where((a) => a.taskId == task.id)) {
         byWorker.putIfAbsent(a.workerId, () => []).add(a);
       }
       if (byWorker.isEmpty) {

--- a/feature/grafik/widget/task/task_list.dart
+++ b/feature/grafik/widget/task/task_list.dart
@@ -55,6 +55,7 @@ class TaskList extends StatelessWidget {
                       tasks: tasks,
                       employees: employees,
                       timeIssues: issues,
+                      assignments: context.read<GrafikCubit>().state.assignments,
                     ),
                   ),
                   TimeIssueRow(timeIssues: issues),

--- a/feature/grafik/widget/task/task_tile.dart
+++ b/feature/grafik/widget/task/task_tile.dart
@@ -4,6 +4,8 @@ import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/enums.dart';
+import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/impl/task_assignment.dart' as impl;
 import '../../constants/enums_ui.dart';
 import '../dialog/grafik_element_popup.dart';
 import 'transfer_list.dart';
@@ -34,7 +36,10 @@ class TaskTile extends StatelessWidget {
   Widget build(BuildContext context) {
     // Pobierz dane
     final state      = context.watch<GrafikCubit>().state;
-    final assignedIds = task.assignments.map((a) => a.workerId).toSet();
+    final assignedIds = state.assignments
+        .where((a) => a.taskId == task.id)
+        .map((a) => a.workerId)
+        .toSet();
     final employees =
         state.employees.where((e) => assignedIds.contains(e.uid));
     final vehicles   = state.vehicles .where((v) => task.carIds.contains(v.id));
@@ -60,10 +65,19 @@ class TaskTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             TaskHeader(task: task, typeIcon: typeIcon, statusIcon: statusIcon),
-            if (task.assignments.isNotEmpty)
+            if (assignedIds.isNotEmpty)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
-                child: AssignmentList(assignments: task.assignments),
+                child: AssignmentList(
+                  assignments: state.assignments
+                      .where((a) => a.taskId == task.id)
+                      .map((a) => impl.TaskAssignment(
+                            workerId: a.workerId,
+                            startDateTime: a.startDateTime,
+                            endDateTime: a.endDateTime,
+                          ))
+                      .toList(),
+                ),
               )
             else
               Padding(

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
+import 'package:kabast/domain/models/grafik/assignment.dart';
 import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
 
@@ -9,7 +10,6 @@ import '../../../../../shared/turbo_grid/widgets/clock_view_delegate.dart';
 import '../../../../../shared/turbo_grid/widgets/simple_text_delegate.dart';
 import '../../../../../theme/app_tokens.dart';
 import '../../dialog/grafik_element_popup.dart';
-import 'package:kabast/domain/models/grafik/impl/task_assignment.dart';
 
 class TaskWeekTile extends StatelessWidget {
   final TaskElement task;
@@ -26,10 +26,8 @@ class TaskWeekTile extends StatelessWidget {
   String _buildEmployeeNames(BuildContext context) {
   final state = context.read<GrafikCubit>().state;
 
-  if (task.assignments.isEmpty) return '';
-
-  final byWorker = <String, List<TaskAssignment>>{};
-  for (final a in task.assignments) {
+  final byWorker = <String, List<Assignment>>{};
+  for (final a in state.assignments.where((a) => a.taskId == task.id)) {
     byWorker.putIfAbsent(a.workerId, () => []).add(a);
   }
 


### PR DESCRIPTION
## Summary
- remove embedded `assignments` field from `TaskElement`
- drop assignments from `TaskElementDto`
- update converters and default strategies
- read assignments from state in UI widgets
- adjust mapping utilities and cubit logic

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fac1532f08333bd919544929be9ed