### PR TITLE
Refactor AssignmentRepository to only use task assignments

### DIFF
--- a/data/repositories/task_assignment_repository.dart
+++ b/data/repositories/task_assignment_repository.dart
@@ -13,4 +13,11 @@ class TaskAssignmentRepository {
   Future<void> saveTaskAssignment(TaskAssignment assignment) {
     return _service.addTaskAssignment(assignment);
   }
+
+  Stream<List<TaskAssignment>> getAssignmentsWithinRange({
+    required DateTime start,
+    required DateTime end,
+  }) {
+    return _service.getAssignmentsWithinRange(start: start, end: end);
+  }
 }

--- a/data/services/task_assignment_firebase_service.dart
+++ b/data/services/task_assignment_firebase_service.dart
@@ -25,4 +25,19 @@ class TaskAssignmentFirebaseService implements ITaskAssignmentService {
     final dto = TaskAssignmentDto.fromDomain(assignment);
     await _firestore.collection('task_assignments').add(dto.toJson());
   }
+
+  @override
+  Stream<List<TaskAssignment>> getAssignmentsWithinRange({
+    required DateTime start,
+    required DateTime end,
+  }) {
+    return _firestore
+        .collection('task_assignments')
+        .where('startDateTime', isLessThanOrEqualTo: Timestamp.fromDate(end))
+        .where('endDateTime', isGreaterThanOrEqualTo: Timestamp.fromDate(start))
+        .snapshots()
+        .map((query) => query.docs
+            .map((doc) => TaskAssignmentDto.fromFirestore(doc).toDomain())
+            .toList());
+  }
 }

--- a/domain/services/i_task_assignment_service.dart
+++ b/domain/services/i_task_assignment_service.dart
@@ -3,4 +3,8 @@ import '../models/grafik/task_assignment.dart';
 abstract class ITaskAssignmentService {
   Stream<List<TaskAssignment>> getAssignmentsForTask(String taskId);
   Future<void> addTaskAssignment(TaskAssignment assignment);
+  Stream<List<TaskAssignment>> getAssignmentsWithinRange({
+    required DateTime start,
+    required DateTime end,
+  });
 }

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -86,7 +86,7 @@ class GrafikCubit extends Cubit<GrafikState> {
         types: ['TaskElement', 'TimeIssueElement'],
       ),
       _employeeRepo.getEmployees(),
-      _assignmentRepo.getAssignments(start: start, end: end),
+      _assignmentRepo.getAssignmentsWithinRange(start: start, end: end),
           (elements, employees, assignments) {
         final tasks = elements.whereType<TaskElement>().toList();
         final issues = elements.whereType<TimeIssueElement>().toList();

--- a/injection.dart
+++ b/injection.dart
@@ -24,9 +24,6 @@ import 'package:kabast/data/repositories/grafik_element_repository.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service_v2.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
 
-import 'package:kabast/data/services/assignment_firebase_service.dart';
-import 'package:kabast/data/repositories/assignment_repository.dart';
-import 'package:kabast/domain/services/i_assignment_service.dart';
 
 import 'package:kabast/data/services/task_assignment_firebase_service.dart';
 import 'package:kabast/data/repositories/task_assignment_repository.dart';
@@ -60,9 +57,6 @@ Future<void> setupLocator() async {
     () => GrafikElementFirebaseServiceV2(getIt<FirebaseFirestore>()),
     instanceName: 'v2',
   );
-  getIt.registerLazySingleton<IAssignmentService>(
-    () => AssignmentFirebaseService(getIt<FirebaseFirestore>()),
-  );
   getIt.registerLazySingleton<ITaskAssignmentService>(
     () => TaskAssignmentFirebaseService(getIt<FirebaseFirestore>()),
   );
@@ -88,8 +82,6 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<AssignmentRepository>(
     () => AssignmentRepository(
-      getIt<IAssignmentService>(),
-      getIt<GrafikElementRepository>(),
       getIt<TaskAssignmentRepository>(),
     ),
   );


### PR DESCRIPTION
## Summary
- expand ITaskAssignmentService with `getAssignmentsWithinRange`
- implement range queries in TaskAssignmentFirebaseService
- add same to TaskAssignmentRepository
- drop old AssignmentService/GrafikElement dependencies from AssignmentRepository
- register updated repository in the locator
- adjust GrafikCubit to call the new method

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb2aff4988333b33c124e3fc32076