### PR TITLE
Switch GrafikCubit to new TaskAssignment model

### DIFF
--- a/feature/grafik/cubit/grafik_mapping_utils.dart
+++ b/feature/grafik/cubit/grafik_mapping_utils.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 import 'package:kabast/domain/models/employee.dart';
-import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 
@@ -8,7 +8,7 @@ Map<String, List<String>> calculateTaskTimeIssueDisplayMapping({
   required List<TaskElement> tasks,
   required List<TimeIssueElement> issues,
   required List<Employee> employees,
-  required List<Assignment> assignments,
+  required List<TaskAssignment> assignments,
 }) {
   final mapping = <String, List<String>>{};
 
@@ -60,12 +60,12 @@ Map<String, List<String>> calculateTaskTimeIssueDisplayMapping({
 Map<String, List<String>> calculateTaskTransferDisplayMapping({
   required List<TaskElement> tasks,
   required List<Employee> employees,
-  required List<Assignment> assignments,
+  required List<TaskAssignment> assignments,
 }) {
   final mapping = <String, List<String>>{};
   final tasksById = {for (final t in tasks) t.id: t};
 
-  final assignmentsByWorker = <String, List<Assignment>>{};
+  final assignmentsByWorker = <String, List<TaskAssignment>>{};
   for (final a in assignments) {
     assignmentsByWorker.putIfAbsent(a.workerId, () => []).add(a);
   }

--- a/feature/grafik/cubit/grafik_state.dart
+++ b/feature/grafik/cubit/grafik_state.dart
@@ -2,13 +2,13 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/domain/models/vehicle.dart';
 import 'package:kabast/domain/models/employee.dart';
-import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
 import 'states/week_grafik_data.dart';
 
 class GrafikState {
   final List<TaskElement> tasks;
   final List<TimeIssueElement> issues;
-  final List<Assignment> assignments;
+  final List<TaskAssignment> assignments;
   final Map<String, List<String>> taskTimeIssueDisplayMapping;
   final Map<String, List<String>> taskTransferDisplayMapping;
   final List<Vehicle> vehicles;
@@ -48,7 +48,7 @@ class GrafikState {
     List<TimeIssueElement>? issues,
     Map<String, List<String>>? taskTimeIssueDisplayMapping,
     Map<String, List<String>>? taskTransferDisplayMapping,
-    List<Assignment>? assignments,
+    List<TaskAssignment>? assignments,
     List<Vehicle>? vehicles,
     List<Employee>? employees,
     String? error,

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -17,7 +17,7 @@ import 'package:kabast/injection.dart';
 import '../../cubit/grafik_cubit.dart';
 import '../task/assignment_list.dart';
 import '../task/vehicle_list.dart';
-import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
 import 'package:kabast/domain/models/grafik/impl/task_assignment.dart' as impl;
 
 Future<void> showGrafikElementPopup(

--- a/feature/grafik/widget/task/employee_daily_summary.dart
+++ b/feature/grafik/widget/task/employee_daily_summary.dart
@@ -5,14 +5,14 @@ import '../../../../domain/models/employee.dart';
 import '../../../../domain/models/grafik/impl/task_element.dart';
 import '../../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../../theme/app_tokens.dart';
-import '../../../../domain/models/grafik/assignment.dart';
+import '../../../../domain/models/grafik/task_assignment.dart';
 import '../../../../domain/models/grafik/enums.dart';
 
 class EmployeeDailySummary extends StatelessWidget {
   final List<TaskElement> tasks;
   final List<Employee> employees;
   final List<TimeIssueElement> timeIssues;
-  final List<Assignment> assignments;
+  final List<TaskAssignment> assignments;
 
   const EmployeeDailySummary({
     super.key,

--- a/feature/grafik/widget/task/task_header.dart
+++ b/feature/grafik/widget/task/task_header.dart
@@ -3,7 +3,7 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../cubit/grafik_cubit.dart';
-import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
 
 class TaskHeader extends StatelessWidget {
   final TaskElement task;
@@ -23,7 +23,7 @@ class TaskHeader extends StatelessWidget {
         '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
     Widget _timeWidget() {
       final state = context.read<GrafikCubit>().state;
-      final byWorker = <String, List<Assignment>>{};
+      final byWorker = <String, List<TaskAssignment>>{};
       for (final a in state.assignments.where((a) => a.taskId == task.id)) {
         byWorker.putIfAbsent(a.workerId, () => []).add(a);
       }

--- a/feature/grafik/widget/task/task_tile.dart
+++ b/feature/grafik/widget/task/task_tile.dart
@@ -4,7 +4,7 @@ import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/enums.dart';
-import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
 import 'package:kabast/domain/models/grafik/impl/task_assignment.dart' as impl;
 import '../../constants/enums_ui.dart';
 import '../dialog/grafik_element_popup.dart';

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
-import 'package:kabast/domain/models/grafik/assignment.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
 import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
 
@@ -26,7 +26,7 @@ class TaskWeekTile extends StatelessWidget {
   String _buildEmployeeNames(BuildContext context) {
   final state = context.read<GrafikCubit>().state;
 
-  final byWorker = <String, List<Assignment>>{};
+  final byWorker = <String, List<TaskAssignment>>{};
   for (final a in state.assignments.where((a) => a.taskId == task.id)) {
     byWorker.putIfAbsent(a.workerId, () => []).add(a);
   }

--- a/injection.dart
+++ b/injection.dart
@@ -80,11 +80,6 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<TaskAssignmentRepository>(
     () => TaskAssignmentRepository(getIt<ITaskAssignmentService>()),
   );
-  getIt.registerLazySingleton<AssignmentRepository>(
-    () => AssignmentRepository(
-      getIt<TaskAssignmentRepository>(),
-    ),
-  );
   getIt.registerLazySingleton<IGrafikResolver>(
     () => GrafikResolver(getIt<GrafikElementRepository>()),
   );
@@ -110,7 +105,7 @@ Future<void> setupLocator() async {
       getIt<GrafikElementRepository>(),
       getIt<IVehicleWatcherService>(),
       getIt<EmployeeRepository>(),
-      getIt<AssignmentRepository>(),
+      getIt<TaskAssignmentRepository>(),
       getIt<DateCubit>(),
     ),
   );


### PR DESCRIPTION
## Summary
- update GrafikCubit to stream TaskAssignments
- adjust mapping utils and GrafikState for new data type
- refactor widgets to expect TaskAssignment
- clean up DI to inject TaskAssignmentRepository

## Testing
- `dart` was unavailable so no static analysis was run

------
https://chatgpt.com/codex/tasks/task_e_686fb7038f8083338ee69932b43ad424