### PR TITLE
Handle missing employees gracefully

### DIFF
--- a/feature/grafik/widget/task/assignment_list.dart
+++ b/feature/grafik/widget/task/assignment_list.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:kabast/domain/models/grafik/impl/task_assignment.dart';
+import 'package:kabast/domain/models/employee.dart';
 import '../../cubit/grafik_cubit.dart';
 
 class AssignmentList extends StatelessWidget {
@@ -18,11 +20,9 @@ class AssignmentList extends StatelessWidget {
       byWorker.putIfAbsent(a.workerId, () => []).add(a);
     }
     for (final entry in byWorker.entries) {
-      final emp = state.employees.firstWhere(
-        (e) => e.uid == entry.key,
-        orElse: () => null,
-      );
-      final name = emp?.formattedNameWithSecondInitial ?? entry.key;
+      final Employee? emp =
+          state.employees.firstWhereOrNull((e) => e.uid == entry.key);
+      final name = emp?.formattedNameWithSecondInitial ?? 'Nieznany pracownik';
       final times = entry.value
           .map((a) => '${_fmt(a.startDateTime)}-${_fmt(a.endDateTime)}')
           .join(', ');

--- a/feature/grafik/widget/task/task_header.dart
+++ b/feature/grafik/widget/task/task_header.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:collection/collection.dart';
+import 'package:kabast/domain/models/employee.dart';
 import '../../cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/task_assignment.dart';
 
@@ -36,11 +38,9 @@ class TaskHeader extends StatelessWidget {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: byWorker.entries.map((e) {
-          final emp = state.employees.firstWhere(
-            (el) => el.uid == e.key,
-            orElse: () => null,
-          );
-          final name = emp?.formattedNameWithSecondInitial ?? e.key;
+          final Employee? emp =
+              state.employees.firstWhereOrNull((el) => el.uid == e.key);
+          final name = emp?.formattedNameWithSecondInitial ?? 'Nieznany pracownik';
           final times = e.value
               .map((a) => '${fmt(a.startDateTime)}-${fmt(a.endDateTime)}')
               .join(', ');

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/task_assignment.dart';
+import 'package:kabast/domain/models/employee.dart';
 import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
 
@@ -36,13 +38,11 @@ class TaskWeekTile extends StatelessWidget {
   }
 
   return byWorker.entries.map((e) {
-    final emp = state.employees.firstWhere(
-      (em) => em.uid == e.key,
-      orElse: () => null,
-    );
+    final Employee? emp =
+        state.employees.firstWhereOrNull((em) => em.uid == e.key);
     final name = emp != null
         ? _formatEmployeeName(emp.fullName)
-        : e.key;
+        : 'Nieznany pracownik';
     final times = e.value
         .map((a) =>
             '${a.startDateTime.hour.toString().padLeft(2, '0')}-${a.endDateTime.hour.toString().padLeft(2, '0')}')


### PR DESCRIPTION
## Summary
- import `collection.dart`
- switch to `firstWhereOrNull` in `TaskWeekTile`, `TaskHeader`, and `AssignmentList`
- fall back to `Nieznany pracownik` instead of the worker ID when employee data is missing

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbbdd0a748333bdbedad29386651f