### PR TITLE
Sort assignments chronologically

### DIFF
--- a/feature/grafik/widget/task/assignment_list.dart
+++ b/feature/grafik/widget/task/assignment_list.dart
@@ -24,6 +24,7 @@ class AssignmentList extends StatelessWidget {
           state.employees.firstWhereOrNull((e) => e.uid == entry.key);
       final name = emp?.formattedNameWithSecondInitial ?? 'Nieznany pracownik';
       final times = entry.value
+          .sorted((a, b) => a.startDateTime.compareTo(b.startDateTime))
           .map((a) => '${_fmt(a.startDateTime)}-${_fmt(a.endDateTime)}')
           .join(', ');
       lines.add('$name $times');

--- a/feature/grafik/widget/task/task_header.dart
+++ b/feature/grafik/widget/task/task_header.dart
@@ -42,6 +42,7 @@ class TaskHeader extends StatelessWidget {
               state.employees.firstWhereOrNull((el) => el.uid == e.key);
           final name = emp?.formattedNameWithSecondInitial ?? 'Nieznany pracownik';
           final times = e.value
+              .sorted((a, b) => a.startDateTime.compareTo(b.startDateTime))
               .map((a) => '${fmt(a.startDateTime)}-${fmt(a.endDateTime)}')
               .join(', ');
           return Text('$name $times',

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -44,6 +44,7 @@ class TaskWeekTile extends StatelessWidget {
         ? _formatEmployeeName(emp.fullName)
         : 'Nieznany pracownik';
     final times = e.value
+        .sorted((a, b) => a.startDateTime.compareTo(b.startDateTime))
         .map((a) =>
             '${a.startDateTime.hour.toString().padLeft(2, '0')}-${a.endDateTime.hour.toString().padLeft(2, '0')}')
         .join(', ');


### PR DESCRIPTION
## Summary
- sort employee assignments by `startDateTime` in `TaskWeekTile`
- do the same in `TaskHeader` and `AssignmentList`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc187f71c8333b436e764fc7168d5