### PR TITLE
Remove unused parameter

### DIFF
--- a/domain/models/grafik/impl/task_planning_to_task_extension.dart
+++ b/domain/models/grafik/impl/task_planning_to_task_extension.dart
@@ -7,7 +7,6 @@ extension ToTaskElement on TaskPlanningElement {
   TaskElement toTaskElement({
     DateTime? start,
     int? durationMinutes,
-    List<String>? overrideWorkerIds,
   }) {
     final DateTime s = start ?? startDateTime;
     final DateTime e = s.add(


### PR DESCRIPTION
## Summary
- drop the unused `overrideWorkerIds` argument from `toTaskElement`
- run `flutter analyze`

## Testing
- `flutter analyze` *(fails: undefined Flutter symbols)*

------
https://chatgpt.com/codex/tasks/task_e_686fca806da4833398cf23fe6a6c17f6