### PR TITLE
Fix week data subscription handling

### DIFF
--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -144,6 +144,9 @@ class GrafikCubit extends Cubit<GrafikState> {
     );
 
     final employeeStream = _employeeRepo.getEmployees();
+    try {
+      _weekDataSub.cancel();
+    } catch (_) {}
 
     _weekDataSub = Rx.combineLatest2<List<GrafikElement>, List<Employee>, Map<String, dynamic>>(
       grafikStream,


### PR DESCRIPTION
## Summary
- cancel previous week data subscription in GrafikCubit

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd9b4aa4483339635f1cfc93956c3