### PR TITLE
Add deleteAssignmentsForTask

### DIFF
--- a/data/repositories/task_assignment_repository.dart
+++ b/data/repositories/task_assignment_repository.dart
@@ -14,6 +14,10 @@ class TaskAssignmentRepository {
     return _service.addTaskAssignment(assignment);
   }
 
+  Future<void> deleteAssignmentsForTask(String taskId) {
+    return _service.deleteAssignmentsForTask(taskId);
+  }
+
   Stream<List<TaskAssignment>> getAssignmentsWithinRange({
     required DateTime start,
     required DateTime end,

--- a/data/services/task_assignment_firebase_service.dart
+++ b/data/services/task_assignment_firebase_service.dart
@@ -27,6 +27,17 @@ class TaskAssignmentFirebaseService implements ITaskAssignmentService {
   }
 
   @override
+  Future<void> deleteAssignmentsForTask(String taskId) async {
+    final query = await _firestore
+        .collection('task_assignments')
+        .where('taskId', isEqualTo: taskId)
+        .get();
+    for (final doc in query.docs) {
+      await doc.reference.delete();
+    }
+  }
+
+  @override
   Stream<List<TaskAssignment>> getAssignmentsWithinRange({
     required DateTime start,
     required DateTime end,

--- a/domain/services/i_task_assignment_service.dart
+++ b/domain/services/i_task_assignment_service.dart
@@ -3,6 +3,7 @@ import '../models/grafik/task_assignment.dart';
 abstract class ITaskAssignmentService {
   Stream<List<TaskAssignment>> getAssignmentsForTask(String taskId);
   Future<void> addTaskAssignment(TaskAssignment assignment);
+  Future<void> deleteAssignmentsForTask(String taskId);
   Stream<List<TaskAssignment>> getAssignmentsWithinRange({
     required DateTime start,
     required DateTime end,

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
 import 'package:kabast/data/repositories/app_user_repository.dart';
+import 'package:kabast/data/repositories/task_assignment_repository.dart';
 import 'package:kabast/domain/models/grafik/grafik_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
@@ -53,6 +54,7 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
 
   final _repo = getIt<GrafikElementRepository>();
   final _userRepo = getIt<AppUserRepository>();
+  final _assignmentRepo = getIt<TaskAssignmentRepository>();
   String? _userFullName;
 
   @override
@@ -157,8 +159,10 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
             PermissionWidget(
               permission: 'canEditGrafik',
               child: TextButton(
-                onPressed: () {
-                  getIt<GrafikElementRepository>().deleteGrafikElement(_element.id);
+                onPressed: () async {
+                  await getIt<GrafikElementRepository>()
+                      .deleteGrafikElement(_element.id);
+                  await _assignmentRepo.deleteAssignmentsForTask(_element.id);
                   Navigator.of(context).pop();
                 },
                 child: const Text('Usuń'),


### PR DESCRIPTION
## Summary
- extend `ITaskAssignmentService` with `deleteAssignmentsForTask`
- implement deletion logic in `TaskAssignmentFirebaseService`
- expose new method from `TaskAssignmentRepository`
- remove assignments when a task is deleted in the popup

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd9b88a048333bc47c7771d37a6ac