### PR TITLE
Rename simplified TaskAssignment model

### DIFF
--- a/domain/models/grafik/impl/display_task_assignment.dart
+++ b/domain/models/grafik/impl/display_task_assignment.dart
@@ -1,9 +1,10 @@
-class TaskAssignment {
+/// Simplified version of [TaskAssignment] used only for displaying data.
+class DisplayTaskAssignment {
   final String workerId;
   final DateTime startDateTime;
   final DateTime endDateTime;
 
-  TaskAssignment({
+  DisplayTaskAssignment({
     required this.workerId,
     required this.startDateTime,
     required this.endDateTime,

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -18,7 +18,8 @@ import '../../cubit/grafik_cubit.dart';
 import '../task/assignment_list.dart';
 import '../task/vehicle_list.dart';
 import 'package:kabast/domain/models/grafik/task_assignment.dart';
-import 'package:kabast/domain/models/grafik/impl/task_assignment.dart' as impl;
+import 'package:kabast/domain/models/grafik/impl/display_task_assignment.dart'
+    as display;
 
 Future<void> showGrafikElementPopup(
     BuildContext parentContext,
@@ -186,7 +187,7 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
   List<Widget> _buildTaskElementDetails(BuildContext context, TaskElement task) {
     final assignments = context.read<GrafikCubit>().state.assignments
         .where((a) => a.taskId == task.id)
-        .map((a) => impl.TaskAssignment(
+        .map((a) => display.DisplayTaskAssignment(
               workerId: a.workerId,
               startDateTime: a.startDateTime,
               endDateTime: a.endDateTime,

--- a/feature/grafik/widget/task/assignment_list.dart
+++ b/feature/grafik/widget/task/assignment_list.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:collection/collection.dart';
-import 'package:kabast/domain/models/grafik/impl/task_assignment.dart';
+import 'package:kabast/domain/models/grafik/impl/display_task_assignment.dart';
 import 'package:kabast/domain/models/employee.dart';
 import '../../cubit/grafik_cubit.dart';
 
 class AssignmentList extends StatelessWidget {
-  final List<TaskAssignment> assignments;
+  final List<DisplayTaskAssignment> assignments;
   const AssignmentList({Key? key, required this.assignments}) : super(key: key);
 
   String _fmt(DateTime dt) => '${dt.hour.toString().padLeft(2,'0')}:${dt.minute.toString().padLeft(2,'0')}';
@@ -15,7 +15,7 @@ class AssignmentList extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = context.read<GrafikCubit>().state;
     final lines = <String>[];
-    final byWorker = <String, List<TaskAssignment>>{};
+    final byWorker = <String, List<DisplayTaskAssignment>>{};
     for (final a in assignments) {
       byWorker.putIfAbsent(a.workerId, () => []).add(a);
     }

--- a/feature/grafik/widget/task/task_tile.dart
+++ b/feature/grafik/widget/task/task_tile.dart
@@ -5,7 +5,8 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/enums.dart';
 import 'package:kabast/domain/models/grafik/task_assignment.dart';
-import 'package:kabast/domain/models/grafik/impl/task_assignment.dart' as impl;
+import 'package:kabast/domain/models/grafik/impl/display_task_assignment.dart'
+    as display;
 import '../../constants/enums_ui.dart';
 import '../dialog/grafik_element_popup.dart';
 import 'transfer_list.dart';
@@ -71,7 +72,7 @@ class TaskTile extends StatelessWidget {
                 child: AssignmentList(
                   assignments: state.assignments
                       .where((a) => a.taskId == task.id)
-                      .map((a) => impl.TaskAssignment(
+                      .map((a) => display.DisplayTaskAssignment(
                             workerId: a.workerId,
                             startDateTime: a.startDateTime,
                             endDateTime: a.endDateTime,


### PR DESCRIPTION
## Summary
- rename the short `TaskAssignment` class to `DisplayTaskAssignment`
- update widget imports and usage to refer to new class

## Testing
- `bash`: no tests present

------
https://chatgpt.com/codex/tasks/task_e_686fd9b5a5008333972af5e48e796f88