### PR TITLE
Add standard form field and section widgets

### DIFF
--- a/shared/form/standard/standard_form_field.dart
+++ b/shared/form/standard/standard_form_field.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:kabast/theme/app_tokens.dart';
+
+class StandardFormField extends StatelessWidget {
+  final String label;
+  final Widget child;
+  final String? helperText;
+  final String? tooltip;
+
+  const StandardFormField({
+    Key? key,
+    required this.label,
+    required this.child,
+    this.helperText,
+    this.tooltip,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final labelRow = Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(label, style: theme.textTheme.bodyMedium),
+        if (tooltip != null)
+          Padding(
+            padding: const EdgeInsets.only(left: AppSpacing.xxs),
+            child: Tooltip(
+              message: tooltip!,
+              child: const Icon(Icons.info_outline, size: 16),
+            ),
+          ),
+      ],
+    );
+
+    final helper = helperText != null
+        ? Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.xs),
+            child: Text(
+              helperText!,
+              style: theme.textTheme.bodyMedium,
+            ),
+          )
+        : const SizedBox.shrink();
+
+    return Container(
+      margin: const EdgeInsets.all(AppSpacing.xs),
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          labelRow,
+          const SizedBox(height: AppSpacing.xs),
+          child,
+          helper,
+        ],
+      ),
+    );
+  }
+}

--- a/shared/form/standard/standard_form_section.dart
+++ b/shared/form/standard/standard_form_section.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:kabast/theme/app_tokens.dart';
+
+import 'standard_form_field.dart';
+
+class StandardFormSection extends StatelessWidget {
+  final String? header;
+  final List<StandardFormField> fields;
+
+  const StandardFormSection({
+    Key? key,
+    this.header,
+    required this.fields,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final children = <Widget>[];
+    if (header != null) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+          child: Text(header!, style: theme.textTheme.bodyLarge),
+        ),
+      );
+    }
+
+    for (var i = 0; i < fields.length; i++) {
+      if (i > 0) {
+        children.add(const SizedBox(height: AppSpacing.sm));
+      }
+      children.add(fields[i]);
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      ),
+    );
+  }
+}

--- a/shared/index.dart
+++ b/shared/index.dart
@@ -1,0 +1,4 @@
+export 'custom_fab.dart';
+export 'small_chip.dart';
+export 'form/standard/standard_form_field.dart';
+export 'form/standard/standard_form_section.dart';


### PR DESCRIPTION
## Summary
- add `StandardFormField` widget
- add `StandardFormSection` widget
- expose the new widgets via `shared/index.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ff18546208333ae13763610588ae8