### PR TITLE
Add home route resolver for AuthWrapper

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -5,6 +5,8 @@ import 'feature/extra_options/extra_options_screen.dart';
 import 'feature/grafik/form/grafik_element_form_screen.dart';
 import 'feature/grafik/grafik_wrapper.dart';
 import 'feature/grafik/widget/week/week_grafik_view.dart';
+import 'feature/auth/screen/no_access_screen.dart';
+import 'feature/my_tasks/my_tasks_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -19,6 +21,10 @@ class AppRouter {
         return MaterialPageRoute(
           builder: (_) => const WeekGrafikView(),
         );
+      case '/myTasks':
+        return MaterialPageRoute(builder: (_) => const MyTasksScreen());
+      case '/noAccess':
+        return MaterialPageRoute(builder: (_) => const NoAccessScreen());
       case '/extras':
         return MaterialPageRoute(builder: (_) => const ExtraOptionsScreen());
       case '/addGrafik':

--- a/feature/my_tasks/my_tasks_screen.dart
+++ b/feature/my_tasks/my_tasks_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class MyTasksScreen extends StatelessWidget {
+  const MyTasksScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Moje zadania'),
+      ),
+      body: const Center(
+        child: Text('My Tasks screen'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add MyTasks screen and router support
- extend AppRouter with /noAccess and /myTasks routes
- resolve home route based on user permissions in `AuthWrapper`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff18f26d88333816a9aebef099e01