### PR TITLE
Add responsive scaffolds and breakpoint system

### DIFF
--- a/feature/auth/screen/login_screen.dart
+++ b/feature/auth/screen/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import '../auth_cubit.dart';
 import '../auth_state.dart';
@@ -23,16 +24,19 @@ class LoginScreen extends StatelessWidget {
           );
         }
       },
-      child: Scaffold(
+      child: ResponsiveScaffold(
         body: LayoutBuilder(
           builder: (context, constraints) {
             return SingleChildScrollView(
-              padding: const EdgeInsets.all(AppSpacing.sm * 4),
-              child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  minHeight: constraints.maxHeight,
-                  maxWidth: 400,
-                ),
+              child: ResponsivePadding(
+                small: EdgeInsets.all(AppSpacing.sm * 4),
+                medium: EdgeInsets.all(AppSpacing.sm * 6),
+                large: EdgeInsets.all(AppSpacing.sm * 8),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: constraints.maxHeight,
+                    maxWidth: 400,
+                  ),
                 child: Center(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,

--- a/feature/auth/screen/no_access_screen.dart
+++ b/feature/auth/screen/no_access_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/shared/appbar/grafik_appbar.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 
 class NoAccessScreen extends StatelessWidget {
@@ -9,11 +10,13 @@ class NoAccessScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context).textTheme;
 
-    return Scaffold(
+    return ResponsiveScaffold(
       appBar: GrafikAppBar(title: Text(AppStrings.noAccessTitle, style: theme.titleLarge)),
       body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.sm * 4),
+        child: ResponsivePadding(
+          small: EdgeInsets.all(AppSpacing.sm * 4),
+          medium: EdgeInsets.all(AppSpacing.sm * 6),
+          large: EdgeInsets.all(AppSpacing.sm * 8),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [

--- a/feature/auth/screen/register_user_widget.dart
+++ b/feature/auth/screen/register_user_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import '../auth_cubit.dart';
 import '../auth_state.dart';
@@ -23,16 +24,19 @@ class RegisterUserWidget extends StatelessWidget {
           );
         }
       },
-      child: Scaffold(
+      child: ResponsiveScaffold(
         body: LayoutBuilder(
           builder: (context, constraints) {
             return SingleChildScrollView(
-              padding: const EdgeInsets.all(AppSpacing.sm * 4),
-              child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  minHeight: constraints.maxHeight,
-                  maxWidth: 400,
-                ),
+              child: ResponsivePadding(
+                small: EdgeInsets.all(AppSpacing.sm * 4),
+                medium: EdgeInsets.all(AppSpacing.sm * 6),
+                large: EdgeInsets.all(AppSpacing.sm * 8),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: constraints.maxHeight,
+                    maxWidth: 400,
+                  ),
                 child: Center(
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -56,6 +60,7 @@ class RegisterUserWidget extends StatelessWidget {
                       ),
                     ],
                   ),
+                ),
                 ),
               ),
             );

--- a/feature/extra_options/extra_options_screen.dart
+++ b/feature/extra_options/extra_options_screen.dart
@@ -1,24 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class ExtraOptionsScreen extends StatelessWidget {
   const ExtraOptionsScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return ResponsiveScaffold(
       appBar: AppBar(
         title: const Text('Dodatkowe opcje'),
       ),
       body: LayoutBuilder(
         builder: (context, constraints) {
           return SingleChildScrollView(
-            padding: const EdgeInsets.all(16.0),
-            child: ConstrainedBox(
-              constraints: BoxConstraints(minHeight: constraints.maxHeight),
-              child: Center(
-                child: Text(
-                  'Dwa tygodnei zdalnego i mogą być tu cuda',
-                  style: Theme.of(context).textTheme.bodyLarge,
+            child: ResponsivePadding(
+              small: const EdgeInsets.all(16.0),
+              medium: const EdgeInsets.all(24.0),
+              large: const EdgeInsets.all(32.0),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Center(
+                  child: Text(
+                    'Dwa tygodnei zdalnego i mogą być tu cuda',
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
                 ),
               ),
             ),

--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/feature/grafik/widget/task/task_list.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
@@ -16,7 +17,7 @@ class SingleDayGrafikView extends StatelessWidget {
   Widget build(BuildContext context) {
     final selectedDay = context.watch<DateCubit>().state.selectedDay;
 
-    return Scaffold(
+    return ResponsiveScaffold(
       appBar: GrafikAppBar(
         title: Text('${AppStrings.grafik}: ${_formatDate(selectedDay)}'),
         actions: [
@@ -54,7 +55,12 @@ class SingleDayGrafikView extends StatelessWidget {
         ],
       ),
 
-      body: TaskList(date: selectedDay), // 🔁 ważne: użyj wybranego dnia z Cubita
+      body: ResponsivePadding(
+        small: const EdgeInsets.all(AppSpacing.sm),
+        medium: const EdgeInsets.all(AppSpacing.sm * 2),
+        large: const EdgeInsets.all(AppSpacing.sm * 3),
+        child: TaskList(date: selectedDay),
+      ), // 🔁 ważne: użyj wybranego dnia z Cubita
 
       floatingActionButton: PermissionWidget(
         permission: 'canAddGrafik',

--- a/feature/grafik/widget/week/week_grafik_view.dart
+++ b/feature/grafik/widget/week/week_grafik_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:kabast/feature/grafik/widget/week/grafik_planning_stack.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import '../pending_task_column.dart';
 import '../../../../shared/appbar/grafik_appbar.dart';
@@ -14,7 +15,7 @@ class WeekGrafikView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return ResponsiveScaffold(
       appBar: GrafikAppBar(
         title: BlocBuilder<DateCubit, DateState>(
           builder: (context, dateState) {
@@ -58,8 +59,12 @@ class WeekGrafikView extends StatelessWidget {
       // ────────────────────────────────────────────────────────────
       //  Główne body  →  grafiki + (opcjonalnie) boczna kolumna
       // ────────────────────────────────────────────────────────────
-      body: LayoutBuilder(
-        builder: (context, constraints) {
+      body: ResponsivePadding(
+        small: const EdgeInsets.all(AppSpacing.sm),
+        medium: const EdgeInsets.all(AppSpacing.sm * 2),
+        large: const EdgeInsets.all(AppSpacing.sm * 3),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
           if (constraints.maxWidth > 1000) {
             return Row(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -81,6 +86,7 @@ class WeekGrafikView extends StatelessWidget {
           // Wąskie ekrany → tylko grafik
           return const GrafikPlanningStack();
         },
+        ),
       ),
 
       floatingActionButton: PermissionWidget(

--- a/shared/responsive/responsive_layout.dart
+++ b/shared/responsive/responsive_layout.dart
@@ -1,0 +1,106 @@
+import "package:flutter/material.dart";
+enum Breakpoint { small, medium, large }
+
+class BreakpointProvider extends InheritedWidget {
+  final Breakpoint breakpoint;
+  const BreakpointProvider({
+    super.key,
+    required this.breakpoint,
+    required super.child,
+  });
+
+  static Breakpoint of(BuildContext context) {
+    final provider =
+        context.dependOnInheritedWidgetOfExactType<BreakpointProvider>();
+    return provider?.breakpoint ?? Breakpoint.small;
+  }
+
+  @override
+  bool updateShouldNotify(covariant BreakpointProvider oldWidget) =>
+      oldWidget.breakpoint != breakpoint;
+}
+
+class ResponsiveScaffold extends StatelessWidget {
+  final PreferredSizeWidget? appBar;
+  final Widget? body;
+  final Widget? floatingActionButton;
+  final Widget? drawer;
+  final Widget? bottomNavigationBar;
+
+  const ResponsiveScaffold({
+    super.key,
+    this.appBar,
+    this.body,
+    this.floatingActionButton,
+    this.drawer,
+    this.bottomNavigationBar,
+  });
+
+  Breakpoint _fromWidth(double width) {
+    if (width < 600) return Breakpoint.small;
+    if (width < 1000) return Breakpoint.medium;
+    return Breakpoint.large;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth == double.infinity
+            ? MediaQuery.of(context).size.width
+            : constraints.maxWidth;
+        final bp = _fromWidth(width);
+        return BreakpointProvider(
+          breakpoint: bp,
+          child: Scaffold(
+            appBar: appBar,
+            body: body,
+            floatingActionButton: floatingActionButton,
+            drawer: drawer,
+            bottomNavigationBar: bottomNavigationBar,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class ResponsivePadding extends StatelessWidget {
+  final Widget child;
+  final EdgeInsets? small;
+  final EdgeInsets? medium;
+  final EdgeInsets? large;
+
+  const ResponsivePadding({
+    super.key,
+    required this.child,
+    this.small,
+    this.medium,
+    this.large,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bp = BreakpointProvider.of(context);
+    EdgeInsets? padding;
+    switch (bp) {
+      case Breakpoint.small:
+        padding = small ?? medium ?? large;
+        break;
+      case Breakpoint.medium:
+        padding = medium ?? large ?? small;
+        break;
+      case Breakpoint.large:
+        padding = large ?? medium ?? small;
+        break;
+    }
+    return Padding(
+      padding: padding ?? EdgeInsets.zero,
+      child: child,
+    );
+  }
+}
+
+extension BreakpointContextX on BuildContext {
+  Breakpoint get breakpoint => BreakpointProvider.of(this);
+}

--- a/shared/small_chip.dart
+++ b/shared/small_chip.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/theme/app_tokens.dart';
+import "package:kabast/theme/theme.dart";
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class SmallChip extends StatelessWidget {
   final String label;
@@ -22,9 +24,13 @@ class SmallChip extends StatelessWidget {
       children: [
         if (icon != null)
           Padding(
-            padding: const EdgeInsets.only(right: AppSpacing.xs), // 2.0
+          padding: EdgeInsets.only(
+            right: AppSpacing.scaled(AppSpacing.xs, context.breakpoint),
+          ),
             child: Container(
-              padding: const EdgeInsets.all(AppSpacing.xxs), // 1.0
+              padding: EdgeInsets.all(
+                AppSpacing.scaled(AppSpacing.xxs, context.breakpoint),
+              ), // 1.0
               decoration: BoxDecoration(
                 border: Border.all(
                   color: Colors.white,
@@ -38,7 +44,10 @@ class SmallChip extends StatelessWidget {
         Flexible(
           child: Text(
             label,
-            style: Theme.of(context).textTheme.bodySmall,
+            style: AppTheme.textStyleFor(
+              context.breakpoint,
+              Theme.of(context).textTheme.bodySmall!,
+            ),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
@@ -53,10 +62,12 @@ class SmallChip extends StatelessWidget {
         constraints: BoxConstraints(
           maxWidth: MediaQuery.of(context).size.width * 0.3,
         ),
-        margin: const EdgeInsets.all(AppSpacing.xxs), // 1.0
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.xs, // 2.0
-          vertical: AppSpacing.xxs,  // 1.0
+        margin: EdgeInsets.all(
+          AppSpacing.scaled(AppSpacing.xxs, context.breakpoint),
+        ), // 1.0
+        padding: EdgeInsets.symmetric(
+          horizontal: AppSpacing.scaled(AppSpacing.xs, context.breakpoint),
+          vertical: AppSpacing.scaled(AppSpacing.xxs, context.breakpoint),
         ),
         decoration: BoxDecoration(
           color: backgroundColor ?? Theme.of(context).chipTheme.backgroundColor,

--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -1,11 +1,25 @@
 
 import 'package:flutter/material.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 /// Stałe odstępów, marginesów, paddingów
 class AppSpacing {
   static const double xxs = 1.0;
   static const double xs = 2.0;
   static const double sm = 4.0;
+
+  static double _scale(Breakpoint bp) {
+    switch (bp) {
+      case Breakpoint.small:
+        return 1.0;
+      case Breakpoint.medium:
+        return 1.5;
+      case Breakpoint.large:
+        return 2.0;
+    }
+  }
+
+  static double scaled(double base, Breakpoint bp) => base * _scale(bp);
 
   /// Szerokość obramowania
   static const double borderThin = 1.0;

--- a/theme/theme.dart
+++ b/theme/theme.dart
@@ -1,7 +1,25 @@
 import 'package:flutter/material.dart';
 import 'app_tokens.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class AppTheme {
+  static double _scaleFor(Breakpoint bp) {
+    switch (bp) {
+      case Breakpoint.small:
+        return 0.8;
+      case Breakpoint.medium:
+        return 1.0;
+      case Breakpoint.large:
+        return 1.2;
+    }
+  }
+
+  static TextStyle textStyleFor(Breakpoint bp, TextStyle style) {
+    final scale = _scaleFor(bp);
+    return style.copyWith(
+      fontSize: style.fontSize != null ? style.fontSize! * scale : null,
+    );
+  }
   static ThemeData buildTheme() {
     final view = WidgetsBinding.instance.platformDispatcher.views.first;
     final width = view.physicalSize.width / view.devicePixelRatio;


### PR DESCRIPTION
## Summary
- add `Breakpoint`, `BreakpointProvider`, `ResponsiveScaffold` and `ResponsivePadding`
- make spacings scalable with breakpoint
- add `textStyleFor` in `AppTheme`
- update `SmallChip` to use new scaling
- replace `Scaffold` with `ResponsiveScaffold` in several screens
- apply responsive padding in screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ff1a246ac8333b9416586880c8972