### PR TITLE
Improve responsive sizes

### DIFF
--- a/feature/grafik/form/standard_task_row.dart
+++ b/feature/grafik/form/standard_task_row.dart
@@ -3,6 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/theme.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 import '../widget/dialog/grafik_element_popup.dart';
 
@@ -55,10 +57,16 @@ class StandardTaskRow extends StatelessWidget {
           showGrafikElementPopup(context, task);
         },
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm, horizontal: AppSpacing.sm),
+          padding: EdgeInsets.symmetric(
+            vertical: AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
+            horizontal: AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
+          ),
           child: Text(
             displayText,
-            style: Theme.of(context).textTheme.bodySmall!.copyWith(fontSize: 22),
+            style: AppTheme.textStyleFor(
+              context.breakpoint,
+              Theme.of(context).textTheme.bodyLarge!,
+            ),
           ),
         ),
       );
@@ -66,7 +74,9 @@ class StandardTaskRow extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(AppSpacing.sm),
+      padding: EdgeInsets.all(
+        AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
+      ),
       color: Colors.grey.shade300, // Kolor tła, by wyróżnić ten obszar.
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/feature/grafik/form/time_issue_row.dart
+++ b/feature/grafik/form/time_issue_row.dart
@@ -3,6 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/theme.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class TimeIssueRow extends StatelessWidget {
   final List<TimeIssueElement> timeIssues;
@@ -42,17 +44,25 @@ class TimeIssueRow extends StatelessWidget {
       final displayText = "$formattedName, $truncatedInfo";
 
       return Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: AppSpacing.sm,
-          horizontal: AppSpacing.sm,
+        padding: EdgeInsets.symmetric(
+          vertical: AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
+          horizontal: AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
         ),
         child: Row(
           children: [
-            const Icon(Icons.warning_amber, size: 22),
-            const SizedBox(width: 6),
+            Icon(
+              Icons.warning_amber,
+              size: AppTheme.sizeFor(context.breakpoint, 22),
+            ),
+            SizedBox(
+              width: AppTheme.sizeFor(context.breakpoint, 6),
+            ),
             Text(
               displayText,
-              style: Theme.of(context).textTheme.bodySmall!.copyWith(fontSize: 22),
+              style: AppTheme.textStyleFor(
+                context.breakpoint,
+                Theme.of(context).textTheme.bodyLarge!,
+              ),
             ),
           ],
         ),
@@ -62,7 +72,9 @@ class TimeIssueRow extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(AppSpacing.sm),
+      padding: EdgeInsets.all(
+        AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
+      ),
       color: Colors.red.shade100,
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,

--- a/feature/grafik/widget/task/employee_chip_list.dart
+++ b/feature/grafik/widget/task/employee_chip_list.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/domain/models/employee.dart';
 import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/theme.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class EmployeeChipList extends StatelessWidget {
   final Iterable<Employee> employees;
@@ -12,16 +14,18 @@ class EmployeeChipList extends StatelessWidget {
     if (employees.isEmpty) return const SizedBox.shrink();
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      padding: EdgeInsets.symmetric(
+        horizontal: AppSpacing.scaled(AppSpacing.sm, context.breakpoint),
+      ),
       child: Wrap(
-        spacing: 4,
-        runSpacing: 4,
-        children: employees.map(_buildChip).toList(),
+        spacing: AppTheme.sizeFor(context.breakpoint, 4),
+        runSpacing: AppTheme.sizeFor(context.breakpoint, 4),
+        children: employees.map((e) => _buildChip(context, e)).toList(),
       ),
     );
   }
 
-  Widget _buildChip(Employee e) {
+  Widget _buildChip(BuildContext context, Employee e) {
     final name = e.formattedNameWithSecondInitial;
     final parts = name.split(' ');
     final surname = parts.first;
@@ -35,25 +39,32 @@ class EmployeeChipList extends StatelessWidget {
             children: [
               TextSpan(
                 text: surname.substring(0, 1),
-                style: const TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 22,
-                  color: Colors.black,
+                style: AppTheme.textStyleFor(
+                  context.breakpoint,
+                  Theme.of(context).textTheme.bodyLarge!.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                      ),
                 ),
               ),
               TextSpan(
                 text: surname.substring(1) + rest,
-                style: const TextStyle(
-                  fontWeight: FontWeight.normal,
-                  fontSize: 22,
-                  color: Colors.black,
+                style: AppTheme.textStyleFor(
+                  context.breakpoint,
+                  Theme.of(context).textTheme.bodyLarge!.copyWith(
+                        fontWeight: FontWeight.normal,
+                        color: Colors.black,
+                      ),
                 ),
               ),
             ],
           ),
         ),
       ),
-      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+      padding: EdgeInsets.symmetric(
+        horizontal: AppTheme.sizeFor(context.breakpoint, 2),
+        vertical: AppTheme.sizeFor(context.breakpoint, 1),
+      ),
       labelPadding: EdgeInsets.zero,
       visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,

--- a/feature/grafik/widget/task/transfer_list.dart
+++ b/feature/grafik/widget/task/transfer_list.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/shared/responsive/responsive_single_line_text.dart';
+import 'package:kabast/theme/theme.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class TransferList extends StatelessWidget {
   final List<String> transferInfo;
@@ -15,11 +17,13 @@ class TransferList extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: transferInfo.map((info) {
         return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 2.0),
+          padding: EdgeInsets.symmetric(
+            vertical: AppTheme.sizeFor(context.breakpoint, 2.0),
+          ),
           child: ResponsiveSingleLineText(
             text: info,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              fontSize: 12,
+              fontSize: AppTheme.sizeFor(context.breakpoint, 12),
               fontStyle: FontStyle.italic,
               color: Colors.purple,
             ),

--- a/theme/theme.dart
+++ b/theme/theme.dart
@@ -20,6 +20,11 @@ class AppTheme {
       fontSize: style.fontSize != null ? style.fontSize! * scale : null,
     );
   }
+
+  /// Scales arbitrary size values according to the current [Breakpoint].
+  static double sizeFor(Breakpoint bp, double size) {
+    return size * _scaleFor(bp);
+  }
   static ThemeData buildTheme() {
     final view = WidgetsBinding.instance.platformDispatcher.views.first;
     final width = view.physicalSize.width / view.devicePixelRatio;


### PR DESCRIPTION
## Summary
- provide a general `sizeFor` helper in `AppTheme`
- use responsive styles in `StandardTaskRow`
- scale fonts and icons in `TimeIssueRow`
- make `EmployeeChipList` responsive
- adapt `TransferList` text size

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff40af44c8333bc63090b297ec469