### PR TITLE
Add dedicated grafik permission

### DIFF
--- a/domain/models/app_user.dart
+++ b/domain/models/app_user.dart
@@ -22,6 +22,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canEditSettings': true,
         'canLogout': true,
         'canChangeDate': true,
+        'canSeeAllGrafik': true,
         'canUseApp': true,
       };
     case UserRole.czlowiekZarzadu:
@@ -35,6 +36,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canEditSettings': true,
         'canLogout': true,
         'canChangeDate': true,
+        'canSeeAllGrafik': true,
         'canUseApp': true,
       };
     case UserRole.kierownik:
@@ -47,6 +49,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canEditSettings': false,
         'canLogout': true,
         'canChangeDate': true,
+        'canSeeAllGrafik': true,
         'canUseApp': true,
       };
     case UserRole.monter:
@@ -59,6 +62,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canEditSettings': false,
         'canLogout': true,
         'canChangeDate': false,
+        'canSeeAllGrafik': false,
         'canUseApp': true,
       };
     case UserRole.hala:
@@ -70,7 +74,8 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canViewServiceTasks': true,
         'canEditSettings': false,
         'canLogout': false,
-        'canChangeDate': false,
+        'canChangeDate': true,
+        'canSeeAllGrafik': false,
         'canUseApp': true,
       };
     case UserRole.kierownikProdukcji:
@@ -83,6 +88,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canEditSettings': false,
         'canLogout': true,
         'canChangeDate': true,
+        'canSeeAllGrafik': true,
         'canUseApp': true,
       };
     default:
@@ -95,6 +101,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canEditSettings': false,
         'canLogout': true,
         'canChangeDate': false,
+        'canSeeAllGrafik': false,
         'canUseApp': false, // tylko user nie może
       };
   }

--- a/feature/auth/wrapper/auth_wrapper.dart
+++ b/feature/auth/wrapper/auth_wrapper.dart
@@ -50,7 +50,7 @@ class AuthWrapper extends StatelessWidget {
       return '/weekGrafik';
     }
 
-    if (perms['canEditGrafik'] == true || perms['canChangeDate'] == true) {
+    if (perms['canEditGrafik'] == true || perms['canSeeAllGrafik'] == true) {
       return '/grafik';
     }
 


### PR DESCRIPTION
## Summary
- allow hala users to change date
- add `canSeeAllGrafik` permission for roles that can access the grafik
- route to grafik only when `canSeeAllGrafik` or editing rights are present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ff5aa0b4c8333bf1ba429d27d26dd