### PR TITLE
Document role based home routes

### DIFF
--- a/docs/roles.md
+++ b/docs/roles.md
@@ -1,0 +1,21 @@
+# Roles and Starting Screens
+
+This document explains how the app picks the initial screen after a user logs in.
+The logic lives in `feature/auth/wrapper/auth_wrapper.dart` inside `_resolveHomeRoute`.
+
+## Permission mapping
+
+The route is resolved in order using the following rules:
+
+1. Users without `canUseApp` are sent to `/noAccess`.
+2. Users with `canSeeWeeklySummary` go to `/weekGrafik`.
+3. Users with `canEditGrafik` or `canSeeAllGrafik` go to `/grafik`.
+4. Everyone else is taken to `/myTasks`.
+
+## Example
+
+A simplified example mapping might look like:
+
+- Users with `canEditGrafik` → `/weekGrafik`
+- Role `hala` → `/grafik`
+- Others with `canUseApp` → `/myTasks`

--- a/feature/auth/wrapper/auth_wrapper.dart
+++ b/feature/auth/wrapper/auth_wrapper.dart
@@ -39,6 +39,8 @@ class AuthWrapper extends StatelessWidget {
     );
   }
 
+  // Determines the home screen after login based on permissions.
+  // The mapping is documented in docs/roles.md for maintainability.
   String _resolveHomeRoute(AppUser user) {
     final perms = user.effectivePermissions;
 


### PR DESCRIPTION
## Summary
- add docs/roles.md describing which permissions lead to which start screen
- reference docs/roles.md next to `_resolveHomeRoute` in AuthWrapper

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff83774348333ac04669e6568073e