### PR TITLE
Update my tasks screen builder

### DIFF
--- a/feature/my_tasks/my_tasks_screen.dart
+++ b/feature/my_tasks/my_tasks_screen.dart
@@ -97,12 +97,15 @@ class MyTasksScreen extends StatelessWidget {
       body: StreamBuilder<List<Map<String, dynamic>>>(
         stream: combined$,
         builder: (context, snapshot) {
-          if (!snapshot.hasData) {
+          if (snapshot.hasError) {
+            return Center(child: Text('Błąd ładowania danych\n${snapshot.error}'));
+          }
+          if (!snapshot.hasData && !snapshot.hasError) {
             return const Center(child: CircularProgressIndicator());
           }
           final items = snapshot.data!;
           if (items.isEmpty) {
-            return const Center(child: Text('Brak zadań na wybrany dzień'));
+            return const Center(child: Text('Brak przypisanych zadań'));
           }
           return ListView.builder(
             itemCount: items.length,


### PR DESCRIPTION
## Summary
- add error handling in MyTasksScreen
- update loading and empty state messages

## Testing
- `dart format --set-exit-if-changed -o none .` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687001155b248333bcded893bc6fa666