### PR TITLE
Add AssignEmployee workflow

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -7,6 +7,7 @@ import 'feature/grafik/grafik_wrapper.dart';
 import 'feature/grafik/widget/week/week_grafik_view.dart';
 import 'feature/auth/screen/no_access_screen.dart';
 import 'feature/my_tasks/my_tasks_screen.dart';
+import 'feature/assign_employee/assign_employee_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -23,6 +24,8 @@ class AppRouter {
         );
       case '/myTasks':
         return MaterialPageRoute(builder: (_) => const MyTasksScreen());
+      case '/assignEmployee':
+        return MaterialPageRoute(builder: (_) => const AssignEmployeeScreen());
       case '/noAccess':
         return MaterialPageRoute(builder: (_) => const NoAccessScreen());
       case '/extras':

--- a/feature/assign_employee/assign_employee_screen.dart
+++ b/feature/assign_employee/assign_employee_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import '../../theme/app_tokens.dart';
+import '../../shared/responsive/responsive_layout.dart';
+import '../../shared/form/custom_button.dart';
+import '../../data/repositories/employee_repository.dart';
+import '../auth/auth_cubit.dart';
+import "../../data/repositories/app_user_repository.dart";
+import '../employee/employee_picker.dart';
+
+class AssignEmployeeScreen extends StatefulWidget {
+  const AssignEmployeeScreen({super.key});
+
+  @override
+  State<AssignEmployeeScreen> createState() => _AssignEmployeeScreenState();
+}
+
+class _AssignEmployeeScreenState extends State<AssignEmployeeScreen> {
+  String? _selectedId;
+
+  @override
+  Widget build(BuildContext context) {
+    final employeeStream = GetIt.I<EmployeeRepository>().getEmployees();
+    return ResponsiveScaffold(
+      appBar: AppBar(title: const Text(AppStrings.assignEmployeeTitle)),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            child: ResponsivePadding(
+              small: const EdgeInsets.all(16),
+              medium: const EdgeInsets.all(24),
+              large: const EdgeInsets.all(32),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    EmployeePicker(
+                      employeeStream: employeeStream,
+                      singleSelection: true,
+                      initialSelectedIds: _selectedId == null ? [] : [_selectedId!],
+                      onSelectionChanged: (employees) {
+                        setState(() {
+                          _selectedId = employees.isNotEmpty ? employees.first.uid : null;
+                        });
+                      },
+                    ),
+                    const SizedBox(height: AppSpacing.sm * 6),
+                    CustomButton(
+                      text: AppStrings.assignMe,
+                      onPressed: _selectedId == null
+                          ? null
+                          : () async {
+                              final user = context.read<AuthCubit>().currentUser;
+                              if (user != null) {
+                                final updated = user.copyWith(employeeId: _selectedId);
+                                await GetIt.I<AppUserRepository>().saveUser(updated);
+                              }
+                              if (mounted) Navigator.of(context).pop();
+                            },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/feature/my_tasks/my_tasks_screen.dart
+++ b/feature/my_tasks/my_tasks_screen.dart
@@ -12,6 +12,7 @@ import '../auth/auth_cubit.dart';
 import '../date/date_cubit.dart';
 import '../permission/permission_widget.dart';
 import '../../shared/responsive/responsive_layout.dart';
+import '../../theme/app_tokens.dart';
 
 class MyTasksScreen extends StatelessWidget {
   const MyTasksScreen({super.key});
@@ -24,6 +25,27 @@ class MyTasksScreen extends StatelessWidget {
     if (user == null) {
       return const Scaffold(
         body: Center(child: Text('Brak użytkownika')),
+      );
+    }
+
+    if (user.employeeId?.isEmpty ?? true) {
+      return ResponsiveScaffold(
+        appBar: AppBar(title: const Text('Moje zadania')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(AppStrings.noEmployeeAssigned),
+              const SizedBox(height: AppSpacing.sm * 3),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamed('/assignEmployee');
+                },
+                child: const Text(AppStrings.assignMe),
+              ),
+            ],
+          ),
+        ),
       );
     }
 

--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -124,4 +124,7 @@ class AppStrings {
   static const registerUser = 'Utwórz użytkownika';
   static const logoAlt = 'Logo aplikacji';
   static const signInError = 'Ups! Coś poszło nie tak. Sprawdź dane logowania i połączenie z internetem.';
+  static const assignEmployeeTitle = 'Przypisz pracownika';
+  static const noEmployeeAssigned = 'Nie przypisano konta do pracownika';
+  static const assignMe = 'Przypisz mnie';
 }


### PR DESCRIPTION
## Summary
- create a basic AssignEmployee workflow with employee picker
- wire new `/assignEmployee` route
- show button in MyTasks when account lacks employee assignment
- add strings for new workflow

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687001f65558833393e351693788990d