### PR TITLE
Implement basic supplies module

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -7,6 +7,7 @@ import 'feature/grafik/grafik_wrapper.dart';
 import 'feature/grafik/widget/week/week_grafik_view.dart';
 import 'feature/auth/screen/no_access_screen.dart';
 import 'feature/my_tasks/my_tasks_screen.dart';
+import 'feature/supplies/supply_list_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -27,6 +28,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const NoAccessScreen());
       case '/extras':
         return MaterialPageRoute(builder: (_) => const ExtraOptionsScreen());
+      case '/supplies':
+        return MaterialPageRoute(builder: (_) => const SupplyListScreen());
       case '/addGrafik':
         final existingElement = settings.arguments as GrafikElement?;
         return MaterialPageRoute(

--- a/data/dto/supply_item_dto.dart
+++ b/data/dto/supply_item_dto.dart
@@ -1,0 +1,75 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/supply_item.dart';
+
+class SupplyItemDto {
+  final String id;
+  final String name;
+  final String category;
+  final int quantityAvailable;
+  final String unit;
+  final DateTime? lastOrderedAt;
+  final int lowStockThreshold;
+
+  SupplyItemDto({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.quantityAvailable,
+    required this.unit,
+    required this.lastOrderedAt,
+    required this.lowStockThreshold,
+  });
+
+  factory SupplyItemDto.fromJson(Map<String, dynamic> json) {
+    return SupplyItemDto(
+      id: json['id'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      category: json['category'] as String? ?? '',
+      quantityAvailable: (json['quantityAvailable'] as num?)?.toInt() ?? 0,
+      unit: json['unit'] as String? ?? '',
+      lastOrderedAt: (json['lastOrderedAt'] as Timestamp?)?.toDate(),
+      lowStockThreshold: (json['lowStockThreshold'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  factory SupplyItemDto.fromFirestore(DocumentSnapshot doc) {
+    final data = (doc.data() as Map<String, dynamic>? ?? {})..putIfAbsent('id', () => doc.id);
+    return SupplyItemDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'category': category,
+      'quantityAvailable': quantityAvailable,
+      'unit': unit,
+      'lastOrderedAt': lastOrderedAt == null ? null : Timestamp.fromDate(lastOrderedAt!),
+      'lowStockThreshold': lowStockThreshold,
+    };
+  }
+
+  SupplyItem toDomain() {
+    return SupplyItem(
+      id: id,
+      name: name,
+      category: category,
+      quantityAvailable: quantityAvailable,
+      unit: unit,
+      lastOrderedAt: lastOrderedAt,
+      lowStockThreshold: lowStockThreshold,
+    );
+  }
+
+  factory SupplyItemDto.fromDomain(SupplyItem item) {
+    return SupplyItemDto(
+      id: item.id,
+      name: item.name,
+      category: item.category,
+      quantityAvailable: item.quantityAvailable,
+      unit: item.unit,
+      lastOrderedAt: item.lastOrderedAt,
+      lowStockThreshold: item.lowStockThreshold,
+    );
+  }
+}

--- a/data/dto/supply_order_dto.dart
+++ b/data/dto/supply_order_dto.dart
@@ -1,0 +1,69 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../domain/models/supply_order.dart';
+
+class SupplyOrderDto {
+  final String id;
+  final String itemId;
+  final String orderedBy;
+  final DateTime orderedAt;
+  final int quantityRequested;
+  final String status;
+
+  SupplyOrderDto({
+    required this.id,
+    required this.itemId,
+    required this.orderedBy,
+    required this.orderedAt,
+    required this.quantityRequested,
+    required this.status,
+  });
+
+  factory SupplyOrderDto.fromJson(Map<String, dynamic> json) {
+    return SupplyOrderDto(
+      id: json['id'] as String? ?? '',
+      itemId: json['itemId'] as String? ?? '',
+      orderedBy: json['orderedBy'] as String? ?? '',
+      orderedAt: (json['orderedAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      quantityRequested: (json['quantityRequested'] as num?)?.toInt() ?? 0,
+      status: json['status'] as String? ?? 'pending',
+    );
+  }
+
+  factory SupplyOrderDto.fromFirestore(DocumentSnapshot doc) {
+    final data = (doc.data() as Map<String, dynamic>? ?? {})..putIfAbsent('id', () => doc.id);
+    return SupplyOrderDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'itemId': itemId,
+      'orderedBy': orderedBy,
+      'orderedAt': Timestamp.fromDate(orderedAt),
+      'quantityRequested': quantityRequested,
+      'status': status,
+    };
+  }
+
+  SupplyOrder toDomain() {
+    return SupplyOrder(
+      id: id,
+      itemId: itemId,
+      orderedBy: orderedBy,
+      orderedAt: orderedAt,
+      quantityRequested: quantityRequested,
+      status: status,
+    );
+  }
+
+  factory SupplyOrderDto.fromDomain(SupplyOrder order) {
+    return SupplyOrderDto(
+      id: order.id,
+      itemId: order.itemId,
+      orderedBy: order.orderedBy,
+      orderedAt: order.orderedAt,
+      quantityRequested: order.quantityRequested,
+      status: order.status,
+    );
+  }
+}

--- a/data/repositories/supply_firebase_repository.dart
+++ b/data/repositories/supply_firebase_repository.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/models/supply_item.dart';
+import '../../domain/models/supply_order.dart';
+import '../../domain/services/i_supply_repository.dart';
+import '../dto/supply_item_dto.dart';
+import '../dto/supply_order_dto.dart';
+
+class SupplyFirebaseRepository implements ISupplyRepository {
+  final FirebaseFirestore _firestore;
+
+  SupplyFirebaseRepository(this._firestore);
+
+  CollectionReference get _items => _firestore.collection('supplies');
+  CollectionReference get _orders => _firestore.collection('supply_orders');
+
+  @override
+  Stream<List<SupplyItem>> watchItems() {
+    return _items.snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => SupplyItemDto.fromFirestore(doc).toDomain())
+          .toList();
+    });
+  }
+
+  @override
+  Future<void> saveItem(SupplyItem item) async {
+    final dto = SupplyItemDto.fromDomain(item);
+    if (item.id.isEmpty) {
+      final ref = await _items.add(dto.toJson());
+      await ref.update({'id': ref.id});
+    } else {
+      await _items.doc(item.id).set(dto.toJson());
+    }
+  }
+
+  @override
+  Future<void> placeOrder(SupplyOrder order) async {
+    final dto = SupplyOrderDto.fromDomain(order);
+    await _orders.add(dto.toJson());
+    // TODO: Integrate with external warehouse system via adapter
+  }
+}

--- a/domain/models/supply_item.dart
+++ b/domain/models/supply_item.dart
@@ -1,0 +1,21 @@
+class SupplyItem {
+  final String id;
+  final String name;
+  final String category;
+  final int quantityAvailable;
+  final String unit;
+  final DateTime? lastOrderedAt;
+  final int lowStockThreshold;
+
+  SupplyItem({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.quantityAvailable,
+    required this.unit,
+    required this.lastOrderedAt,
+    required this.lowStockThreshold,
+  });
+
+  bool get isLowStock => quantityAvailable < lowStockThreshold;
+}

--- a/domain/models/supply_order.dart
+++ b/domain/models/supply_order.dart
@@ -1,0 +1,17 @@
+class SupplyOrder {
+  final String id;
+  final String itemId;
+  final String orderedBy;
+  final DateTime orderedAt;
+  final int quantityRequested;
+  final String status;
+
+  SupplyOrder({
+    required this.id,
+    required this.itemId,
+    required this.orderedBy,
+    required this.orderedAt,
+    required this.quantityRequested,
+    required this.status,
+  });
+}

--- a/domain/services/i_supply_repository.dart
+++ b/domain/services/i_supply_repository.dart
@@ -1,0 +1,9 @@
+import '../models/supply_item.dart';
+import '../models/supply_order.dart';
+
+abstract class ISupplyRepository {
+  Stream<List<SupplyItem>> watchItems();
+  Future<void> saveItem(SupplyItem item);
+
+  Future<void> placeOrder(SupplyOrder order);
+}

--- a/feature/supplies/supply_list_screen.dart
+++ b/feature/supplies/supply_list_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../domain/models/supply_item.dart';
+import '../../domain/services/i_supply_repository.dart';
+import '../../shared/responsive/responsive_layout.dart';
+import 'supply_order_form.dart';
+
+class SupplyListScreen extends StatelessWidget {
+  const SupplyListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = GetIt.instance<ISupplyRepository>();
+    return ResponsiveScaffold(
+      appBar: AppBar(
+        title: const Text('Zaopatrzenie'),
+      ),
+      body: StreamBuilder<List<SupplyItem>>(
+        stream: repo.watchItems(),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(child: Text('Błąd danych\n${snapshot.error}'));
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final items = snapshot.data!;
+          final Map<String, List<SupplyItem>> byCat = {};
+          for (final item in items) {
+            byCat.putIfAbsent(item.category, () => []).add(item);
+          }
+          return ListView(
+            children: byCat.entries.map((e) => _buildCategory(context, e.key, e.value)).toList(),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildCategory(BuildContext context, String category, List<SupplyItem> items) {
+    return ExpansionTile(
+      title: Text(category),
+      children: items.map((item) => _buildItemTile(context, item)).toList(),
+    );
+  }
+
+  Widget _buildItemTile(BuildContext context, SupplyItem item) {
+    final isLow = item.isLowStock;
+    return ListTile(
+      leading: isLow ? const Icon(Icons.warning, color: Colors.red) : null,
+      title: Text(item.name),
+      subtitle: Text('${item.quantityAvailable} ${item.unit}'),
+      trailing: TextButton(
+        child: const Text('Zamów więcej'),
+        onPressed: () => _openOrderForm(context, item),
+      ),
+    );
+  }
+
+  void _openOrderForm(BuildContext context, SupplyItem item) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => SupplyOrderForm(item: item),
+      ),
+    );
+  }
+}

--- a/feature/supplies/supply_order_form.dart
+++ b/feature/supplies/supply_order_form.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../domain/models/supply_item.dart';
+import '../../domain/models/supply_order.dart';
+import '../../domain/services/i_supply_repository.dart';
+import '../auth/auth_cubit.dart';
+import '../../theme/app_tokens.dart';
+
+class SupplyOrderForm extends StatefulWidget {
+  final SupplyItem item;
+
+  const SupplyOrderForm({Key? key, required this.item}) : super(key: key);
+
+  @override
+  State<SupplyOrderForm> createState() => _SupplyOrderFormState();
+}
+
+class _SupplyOrderFormState extends State<SupplyOrderForm> {
+  final _qtyController = TextEditingController(text: '1');
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Zamów: ${widget.item.name}'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Ilość (${widget.item.unit})'),
+            TextField(
+              controller: _qtyController,
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            ElevatedButton(
+              onPressed: _submit,
+              child: const Text('Zamów'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    final qty = int.tryParse(_qtyController.text) ?? 0;
+    if (qty <= 0) return;
+    final user = context.read<AuthCubit>().currentUser;
+    if (user == null) return;
+    final repo = GetIt.instance<ISupplyRepository>();
+    final order = SupplyOrder(
+      id: '',
+      itemId: widget.item.id,
+      orderedBy: user.id,
+      orderedAt: DateTime.now(),
+      quantityRequested: qty,
+      status: 'pending',
+    );
+    await repo.placeOrder(order);
+    if (mounted) Navigator.of(context).pop();
+  }
+}

--- a/injection.dart
+++ b/injection.dart
@@ -23,6 +23,8 @@ import 'package:kabast/feature/date/date_cubit.dart';
 import 'package:kabast/data/repositories/grafik_element_repository.dart';
 import 'package:kabast/data/services/grafik_element_firebase_service_v2.dart';
 import 'package:kabast/domain/services/i_grafik_element_service.dart';
+import 'package:kabast/data/repositories/supply_firebase_repository.dart';
+import 'package:kabast/domain/services/i_supply_repository.dart';
 
 
 import 'package:kabast/data/services/task_assignment_firebase_service.dart';
@@ -59,6 +61,9 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<ITaskAssignmentService>(
     () => TaskAssignmentFirebaseService(getIt<FirebaseFirestore>()),
+  );
+  getIt.registerLazySingleton<ISupplyRepository>(
+    () => SupplyFirebaseRepository(getIt<FirebaseFirestore>()),
   );
 
   // REPOSITORIES


### PR DESCRIPTION
## Summary
- create new domain models `SupplyItem` and `SupplyOrder`
- add `ISupplyRepository` abstraction and a `SupplyFirebaseRepository`
- register repository in `injection.dart`
- provide Firestore DTOs for supply items and orders
- implement `SupplyListScreen` and `SupplyOrderForm`
- expose new `/supplies` route

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687003a25c60833392f7bbeec2181f9e