### PR TITLE
Add employee assignment with conflict check

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -8,6 +8,7 @@ import 'feature/grafik/widget/week/week_grafik_view.dart';
 import 'feature/auth/screen/no_access_screen.dart';
 import 'feature/my_tasks/my_tasks_screen.dart';
 import 'feature/assign_employee/assign_employee_screen.dart';
+import 'feature/my_tasks/assign_employee_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -26,6 +27,9 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const MyTasksScreen());
       case '/assignEmployee':
         return MaterialPageRoute(builder: (_) => const AssignEmployeeScreen());
+      case '/myTasksAssignEmployee':
+        return MaterialPageRoute(
+            builder: (_) => const MyTasksAssignEmployeeScreen());
       case '/noAccess':
         return MaterialPageRoute(builder: (_) => const NoAccessScreen());
       case '/extras':

--- a/feature/my_tasks/assign_employee_screen.dart
+++ b/feature/my_tasks/assign_employee_screen.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../data/repositories/employee_repository.dart';
+import '../../data/repositories/app_user_repository.dart';
+import '../auth/auth_cubit.dart';
+import '../employee/employee_picker.dart';
+import '../../shared/form/custom_button.dart';
+import '../../shared/responsive/responsive_layout.dart';
+import '../../theme/app_tokens.dart';
+
+class MyTasksAssignEmployeeScreen extends StatefulWidget {
+  const MyTasksAssignEmployeeScreen({super.key});
+
+  @override
+  State<MyTasksAssignEmployeeScreen> createState() =>
+      _MyTasksAssignEmployeeScreenState();
+}
+
+class _MyTasksAssignEmployeeScreenState
+    extends State<MyTasksAssignEmployeeScreen> {
+  String? _selectedId;
+  String? _errorText;
+
+  Future<bool> _isEmployeeInUse(String employeeId, String currentUid) async {
+    final firestore = GetIt.I<FirebaseFirestore>();
+    final query = await firestore
+        .collection('users')
+        .where('employeeId', isEqualTo: employeeId)
+        .get();
+    for (final doc in query.docs) {
+      if (doc.id != currentUid) return true;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final employeeStream = GetIt.I<EmployeeRepository>().getEmployees();
+    return ResponsiveScaffold(
+      appBar: AppBar(title: const Text(AppStrings.assignEmployeeTitle)),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            child: ResponsivePadding(
+              small: const EdgeInsets.all(16),
+              medium: const EdgeInsets.all(24),
+              large: const EdgeInsets.all(32),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    EmployeePicker(
+                      employeeStream: employeeStream,
+                      singleSelection: true,
+                      initialSelectedIds: _selectedId == null ? [] : [_selectedId!],
+                      onSelectionChanged: (employees) {
+                        setState(() {
+                          _selectedId =
+                              employees.isNotEmpty ? employees.first.uid : null;
+                          _errorText = null;
+                        });
+                      },
+                    ),
+                    if (_errorText != null) ...[
+                      const SizedBox(height: AppSpacing.sm * 3),
+                      Text(
+                        _errorText!,
+                        style: TextStyle(color: Theme.of(context).colorScheme.error),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.sm * 6),
+                    CustomButton(
+                      text: AppStrings.assignMe,
+                      onPressed: _selectedId == null
+                          ? null
+                          : () async {
+                              final user = context.read<AuthCubit>().currentUser;
+                              if (user == null) return;
+                              final inUse =
+                                  await _isEmployeeInUse(_selectedId!, user.id);
+                              if (inUse) {
+                                if (mounted) {
+                                  setState(() {
+                                    _errorText = AppStrings.employeeAlreadyAssigned;
+                                  });
+                                }
+                                return;
+                              }
+                              final updated = user.copyWith(employeeId: _selectedId);
+                              await GetIt.I<AppUserRepository>().saveUser(updated);
+                              if (mounted) Navigator.of(context).pop();
+                            },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/feature/my_tasks/my_tasks_screen.dart
+++ b/feature/my_tasks/my_tasks_screen.dart
@@ -39,7 +39,7 @@ class MyTasksScreen extends StatelessWidget {
               const SizedBox(height: AppSpacing.sm * 3),
               TextButton(
                 onPressed: () {
-                  Navigator.of(context).pushNamed('/assignEmployee');
+                  Navigator.of(context).pushNamed('/myTasksAssignEmployee');
                 },
                 child: const Text(AppStrings.assignMe),
               ),

--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -127,4 +127,6 @@ class AppStrings {
   static const assignEmployeeTitle = 'Przypisz pracownika';
   static const noEmployeeAssigned = 'Nie przypisano konta do pracownika';
   static const assignMe = 'Przypisz mnie';
+  static const employeeAlreadyAssigned =
+      'Wybrany pracownik jest już przypisany do innego konta';
 }


### PR DESCRIPTION
## Summary
- add unique employee assignment screen under `my_tasks`
- prevent selecting a worker already assigned to another user
- hook new screen into `app_router`
- allow MyTasks screen to open the new route
- add token for duplicate employee message

## Testing
- `dart format -o none -l 120 app_router.dart feature/my_tasks/assign_employee_screen.dart feature/my_tasks/my_tasks_screen.dart theme/app_tokens.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687003c7836c83339d847e9610de1493