### PR TITLE
Add main menu entry point

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -10,6 +10,7 @@ import 'feature/my_tasks/my_tasks_screen.dart';
 import 'feature/supplies/supply_list_screen.dart';
 import 'feature/assign_employee/assign_employee_screen.dart';
 import 'feature/my_tasks/assign_employee_screen.dart';
+import 'feature/main_menu/main_menu_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -24,6 +25,8 @@ class AppRouter {
         return MaterialPageRoute(
           builder: (_) => const WeekGrafikView(),
         );
+      case '/mainMenu':
+        return MaterialPageRoute(builder: (_) => const MainMenuScreen());
       case '/myTasks':
         return MaterialPageRoute(builder: (_) => const MyTasksScreen());
       case '/assignEmployee':

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -8,14 +8,10 @@ The logic lives in `feature/auth/wrapper/auth_wrapper.dart` inside `_resolveHome
 The route is resolved in order using the following rules:
 
 1. Users without `canUseApp` are sent to `/noAccess`.
-2. Users with `canSeeWeeklySummary` go to `/weekGrafik`.
-3. Users with `canEditGrafik` or `canSeeAllGrafik` go to `/grafik`.
-4. Everyone else is taken to `/myTasks`.
+2. Everyone else lands on `/mainMenu`.
 
 ## Example
 
-A simplified example mapping might look like:
-
-- Users with `canEditGrafik` → `/weekGrafik`
-- Role `hala` → `/grafik`
-- Others with `canUseApp` → `/myTasks`
+Previously users were routed directly to specific screens based on permissions.
+After introducing the main menu, all authenticated users with `canUseApp`
+enabled start at `/mainMenu` regardless of other permissions.

--- a/feature/auth/wrapper/auth_wrapper.dart
+++ b/feature/auth/wrapper/auth_wrapper.dart
@@ -48,14 +48,6 @@ class AuthWrapper extends StatelessWidget {
       return '/noAccess';
     }
 
-    if (perms['canSeeWeeklySummary'] == true) {
-      return '/weekGrafik';
-    }
-
-    if (perms['canEditGrafik'] == true || perms['canSeeAllGrafik'] == true) {
-      return '/grafik';
-    }
-
-    return '/myTasks';
+    return '/mainMenu';
   }
 }

--- a/feature/main_menu/main_menu_screen.dart
+++ b/feature/main_menu/main_menu_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../../shared/responsive/responsive_layout.dart';
+import '../permission/permission_widget.dart';
+
+class MainMenuScreen extends StatelessWidget {
+  const MainMenuScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final bp = context.breakpoint;
+    final crossAxisCount = bp == Breakpoint.small
+        ? 1
+        : bp == Breakpoint.medium
+            ? 2
+            : 3;
+
+    Widget buildTile({
+      required IconData icon,
+      required String label,
+      required String route,
+      String? permission,
+    }) {
+      Widget tile = Card(
+        child: InkWell(
+          onTap: () => Navigator.pushNamed(context, route),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, size: 36),
+                const SizedBox(height: 8),
+                Text(label, textAlign: TextAlign.center),
+              ],
+            ),
+          ),
+        ),
+      );
+      return permission == null
+          ? tile
+          : PermissionWidget(permission: permission, child: tile);
+    }
+
+    final items = [
+      buildTile(
+        icon: Icons.calendar_today,
+        label: 'Grafik dzienny',
+        route: '/grafik',
+      ),
+      buildTile(
+        icon: Icons.view_week,
+        label: 'Grafik tygodniowy',
+        route: '/weekGrafik',
+        permission: 'canSeeWeeklySummary',
+      ),
+      buildTile(
+        icon: Icons.inventory,
+        label: 'Zaopatrzenie',
+        route: '/supplies',
+      ),
+    ];
+
+    return ResponsiveScaffold(
+      appBar: AppBar(title: const Text('Menu')),
+      body: GridView.count(
+        padding: const EdgeInsets.all(16),
+        crossAxisCount: crossAxisCount,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+        childAspectRatio: 1.2,
+        children: items,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce MainMenuScreen with responsive grid
- register `/mainMenu` in AppRouter
- route authenticated users with app access to the menu
- update documentation about the new default route

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c4970dc48333ab20ad724ffe1af2