### PR TITLE
Fix imports across grafik feature

### DIFF
--- a/data/dto/grafik/grafik_element_dto.dart
+++ b/data/dto/grafik/grafik_element_dto.dart
@@ -6,6 +6,10 @@ import '../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../../domain/models/grafik/enums.dart';
+import 'task_element_dto.dart';
+import 'time_issue_element_dto.dart';
+import 'delivery_planning_element_dto.dart';
+import 'task_planning_element_dto.dart';
 
 abstract class GrafikElementDto {
   static DateTime parseDateTime(dynamic value, DateTime fallback) {

--- a/feature/auth/wrapper/auth_wrapper.dart
+++ b/feature/auth/wrapper/auth_wrapper.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../auth_cubit.dart';
 import '../auth_state.dart';
-import '../../domain/models/app_user.dart';
+import '../../../domain/models/app_user.dart';
 
 class AuthWrapper extends StatelessWidget {
   final GlobalKey<NavigatorState> navigatorKey;

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -7,6 +7,7 @@ import '../../../data/repositories/grafik_element_repository.dart';
 import '../../../data/repositories/task_assignment_repository.dart';
 import '../../../domain/services/i_vehicle_watcher_service.dart';
 import '../../date/date_cubit.dart';
+import '../../date/date_state.dart';
 import '../../../domain/models/employee.dart';
 import '../../../domain/models/grafik/grafik_element.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';

--- a/feature/grafik/form/components/assignment_editor.dart
+++ b/feature/grafik/form/components/assignment_editor.dart
@@ -9,6 +9,7 @@ import '../../../../domain/models/grafik/task_assignment.dart';
 import '../../../employee/employee_picker.dart';
 import '../../../../shared/datetime/date_time_picker_field.dart';
 import '../../cubit/form/grafik_element_form_cubit.dart';
+import '../../cubit/form/grafik_element_form_state.dart';
 import '../../../../theme/app_tokens.dart';
 
 class AssignmentEditor extends StatefulWidget {

--- a/feature/grafik/form/grafik_element_form_screen.dart
+++ b/feature/grafik/form/grafik_element_form_screen.dart
@@ -11,6 +11,7 @@ import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/standard/standard_form_field.dart';
 import '../../../shared/form/standard/standard_form_section.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
+import '../cubit/form/grafik_element_form_state.dart';
 import '../../../data/repositories/grafik_element_repository.dart';
 import '../../../data/repositories/task_assignment_repository.dart';
 

--- a/feature/grafik/form/task_element_fields.dart
+++ b/feature/grafik/form/task_element_fields.dart
@@ -10,6 +10,7 @@ import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
 import '../../vehicle/widget/vehicle_picker.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
+import '../cubit/form/grafik_element_form_state.dart';
 import '../../../data/repositories/vehicle_repository.dart';
 import 'components/assignment_editor.dart';
 

--- a/feature/grafik/form/task_planning_element_fields.dart
+++ b/feature/grafik/form/task_planning_element_fields.dart
@@ -11,6 +11,7 @@ import '../../../shared/form/minutes_picker/minutes_picker_field.dart';
 import '../../../shared/form/small_number_picker/small_number_picker.dart';
 import '../../../domain/constants/pending_placeholder_date.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
+import '../cubit/form/grafik_element_form_state.dart';
 import 'components/assignment_editor.dart';
 
 class GrafikPlanningFields extends StatelessWidget {

--- a/feature/grafik/grafik_wrapper.dart
+++ b/feature/grafik/grafik_wrapper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
+import 'package:kabast/feature/date/date_state.dart';
 import 'package:kabast/feature/grafik/widget/single_day_grafik_view.dart';
 
 class GrafikWrapper extends StatelessWidget {

--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -12,6 +12,7 @@ import 'package:kabast/feature/grafik/widget/week/tiles/task_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/time_issue_week_tile.dart';
 
 import '../../cubit/grafik_cubit.dart';
+import '../../cubit/grafik_state.dart';
 import '../../../date/date_cubit.dart';
 import 'grafik_grid.dart';
 

--- a/feature/grafik/widget/week/week_grafik_view.dart
+++ b/feature/grafik/widget/week/week_grafik_view.dart
@@ -9,6 +9,7 @@ import '../../../../shared/appbar/grafik_appbar.dart';
 import '../../../../shared/custom_fab.dart';
 import '../../../permission/permission_widget.dart';
 import '../../../date/date_cubit.dart';
+import '../../../date/date_state.dart';
 
 class WeekGrafikView extends StatelessWidget {
   const WeekGrafikView({super.key});


### PR DESCRIPTION
## Summary
- correct DTO imports in grafik_element_dto
- point to AppUser model in domain from AuthWrapper
- include DateState where used in GrafikCubit and grafik widgets
- make GrafikElementForm state available to forms and components

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e88ce7808333a44114e8544f398a