### PR TITLE
Fix spacing constant usage

### DIFF
--- a/feature/employee/employee_tile.dart
+++ b/feature/employee/employee_tile.dart
@@ -50,7 +50,7 @@ class EmployeeTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(AppRadius.md), // 4.0
           border: Border.all(
             color: borderColor,
-            width: 2.0, // możesz dodać AppSpacing.borderMedium = 2.0 w app_tokens
+            width: AppSpacing.borderMedium,
           ),
         ),
         child: LayoutBuilder(

--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -24,6 +24,7 @@ class AppSpacing {
 
   /// Szerokość obramowania
   static const double borderThin = 1.0;
+  static const double borderMedium = 2.0;
 
   /// Odpowiednik .withOpacity(0.1) => alpha ~ 25
   static const int alphaLow = 25;


### PR DESCRIPTION
## Summary
- add `borderMedium` spacing constant
- use `borderMedium` in `EmployeeTile`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6870f28cad308333b775a0531bef0907