### PR TITLE
Improve auth cubit logging and navigation safety

### DIFF
--- a/feature/auth/auth_cubit.dart
+++ b/feature/auth/auth_cubit.dart
@@ -23,10 +23,13 @@ class AuthCubit extends Cubit<AuthState> {
 
   AuthCubit(this._authService) : super(AuthInitial()) {
     _authSub = _authService.authStateChanges().listen((appUser) {
+      print('AuthCubit auth state change: user=$appUser');
       _currentUser = appUser;
       if (appUser != null) {
+        print('AuthCubit emitting AuthAuthenticated');
         emit(AuthAuthenticated());
       } else {
+        print('AuthCubit emitting AuthUnauthenticated');
         emit(AuthUnauthenticated());
       }
     });
@@ -55,6 +58,10 @@ class AuthCubit extends Cubit<AuthState> {
 
 
   Future<void> signIn() async {
+    if (_currentUser != null) {
+      print('signIn skipped: user already authenticated');
+      return;
+    }
     try {
       emit(AuthLoading());
       await _authService.signIn(

--- a/feature/auth/screen/login_screen.dart
+++ b/feature/auth/screen/login_screen.dart
@@ -64,7 +64,7 @@ class LoginScreen extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                         children: [
                           TextButton(
-                            onPressed: authCubit.signIn,
+                            onPressed: () => authCubit.signIn(),
                             child: const Text(AppStrings.login),
                           ),
                         ],

--- a/feature/auth/wrapper/auth_wrapper.dart
+++ b/feature/auth/wrapper/auth_wrapper.dart
@@ -18,18 +18,25 @@ class AuthWrapper extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocListener<AuthCubit, AuthState>(
       listener: (context, state) {
+        final navContext = navigatorKey.currentContext;
+        if (navContext == null) {
+          print('AuthWrapper listener: navigator context is null');
+          return;
+        }
         final navigator = navigatorKey.currentState;
         // Pobieramy bieżącą nazwę trasy.
-        final currentRoute = ModalRoute.of(navigatorKey.currentContext!)?.settings.name;
+        final currentRoute = ModalRoute.of(navContext)?.settings.name;
         final user = context.read<AuthCubit>().currentUser;
 
         if (state is AuthAuthenticated && user != null) {
           final homeRoute = _resolveHomeRoute(user);
+          print('AuthWrapper: current=$currentRoute target=$homeRoute');
           if (currentRoute != homeRoute) {
             navigator?.pushNamedAndRemoveUntil(homeRoute, (_) => false);
           }
         } else if (state is AuthUnauthenticated) {
           // Nawiguj do '/login' tylko, jeśli nie jesteśmy już na ekranie logowania.
+          print('AuthWrapper: current=$currentRoute target=/login');
           if (currentRoute != '/login') {
             navigator?.pushNamedAndRemoveUntil('/login', (_) => false);
           }


### PR DESCRIPTION
## Summary
- guard navigator context before accessing it in `AuthWrapper`
- prevent duplicate sign-ins in `AuthCubit`
- log auth state changes and navigation decisions for easier debugging
- clarify login button callback

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f72eefcc8333b9755b0f3028c6ea