### PR TITLE
Add debug prints for authentication flow

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -14,6 +14,7 @@ import 'feature/main_menu/main_menu_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
+    print('[AppRouter] generateRoute: ${settings.name}');
     switch (settings.name) {
       case '/login':
         return MaterialPageRoute(builder: (_) => const LoginScreen());

--- a/feature/assign_employee/assign_employee_screen.dart
+++ b/feature/assign_employee/assign_employee_screen.dart
@@ -53,6 +53,7 @@ class _AssignEmployeeScreenState extends State<AssignEmployeeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    print('[AssignEmployeeScreen] build');
     final employeeStream = GetIt.I<EmployeeRepository>().getEmployees();
     return ResponsiveScaffold(
       appBar: AppBar(title: const Text(AppStrings.assignEmployeeTitle)),

--- a/feature/auth/auth_cubit.dart
+++ b/feature/auth/auth_cubit.dart
@@ -28,9 +28,11 @@ class AuthCubit extends Cubit<AuthState> {
       if (appUser != null) {
         print('AuthCubit emitting AuthAuthenticated');
         emit(AuthAuthenticated());
+        print('AuthCubit emitted AuthAuthenticated');
       } else {
         print('AuthCubit emitting AuthUnauthenticated');
         emit(AuthUnauthenticated());
+        print('AuthCubit emitted AuthUnauthenticated');
       }
     });
   }
@@ -46,13 +48,18 @@ class AuthCubit extends Cubit<AuthState> {
 
   Future<void> signUp() async {
     try {
+      print('AuthCubit signUp()');
       emit(AuthLoading());
+      print('AuthCubit emitted AuthLoading');
       await _authService.signUp(
         _loginEmail.trim(),
         _loginPassword.trim(),
       );
+      print('AuthCubit signUp completed');
     } catch (e) {
+      print('AuthCubit signUp error: $e');
       emit(AuthError(e.toString()));
+      print('AuthCubit emitted AuthError');
     }
   }
 
@@ -63,24 +70,35 @@ class AuthCubit extends Cubit<AuthState> {
       return;
     }
     try {
+      print('AuthCubit signIn()');
       emit(AuthLoading());
+      print('AuthCubit emitted AuthLoading');
       await _authService.signIn(
         _loginEmail.trim(),
         _loginPassword.trim(),
       );
+      print('AuthCubit signIn completed');
       _clearLoginFields();
     } catch (e) {
+      print('AuthCubit signIn error: $e');
       emit(AuthError(e.toString()));
+      print('AuthCubit emitted AuthError');
     }
   }
 
   Future<void> signOut() async {
     try {
+      print('AuthCubit signOut()');
       emit(AuthLoading());
+      print('AuthCubit emitted AuthLoading');
       await _authService.signOut();
+      print('AuthCubit signOut completed');
       emit(AuthUnauthenticated());
+      print('AuthCubit emitted AuthUnauthenticated');
     } catch (e) {
+      print('AuthCubit signOut error: $e');
       emit(AuthError(e.toString()));
+      print('AuthCubit emitted AuthError');
     }
   }
 

--- a/feature/auth/screen/login_screen.dart
+++ b/feature/auth/screen/login_screen.dart
@@ -10,6 +10,7 @@ class LoginScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[LoginScreen] build');
     final authCubit = context.read<AuthCubit>();
     final theme = Theme.of(context);
 

--- a/feature/auth/screen/no_access_screen.dart
+++ b/feature/auth/screen/no_access_screen.dart
@@ -8,6 +8,7 @@ class NoAccessScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[NoAccessScreen] build');
     final theme = Theme.of(context).textTheme;
 
     return ResponsiveScaffold(

--- a/feature/auth/wrapper/auth_wrapper.dart
+++ b/feature/auth/wrapper/auth_wrapper.dart
@@ -47,6 +47,7 @@ class _AuthWrapperState extends State<AuthWrapper> {
   void _handleState(AuthState state) {
     final ctx = widget.navigatorKey.currentContext;
     final navState = widget.navigatorKey.currentState;
+    print('[AuthWrapper] ctx=$ctx navState=$navState');
     if (ctx == null || navState == null) {
       print('[AuthWrapper] Skipped navigation: navigator not ready');
       WidgetsBinding.instance.addPostFrameCallback((_) => _handleState(state));
@@ -60,8 +61,10 @@ class _AuthWrapperState extends State<AuthWrapper> {
     String? targetRoute;
     if (state is AuthAuthenticated && user != null) {
       targetRoute = _resolveHomeRoute(user);
+      print('[AuthWrapper] resolved route: $targetRoute');
     } else if (state is AuthUnauthenticated) {
       targetRoute = '/login';
+      print('[AuthWrapper] resolved route: $targetRoute');
     }
 
     if (targetRoute != null && currentRoute != targetRoute) {
@@ -74,6 +77,7 @@ class _AuthWrapperState extends State<AuthWrapper> {
         }
         print('[AuthWrapper] executing navigation callback');
         nav.pushNamedAndRemoveUntil(targetRoute!, (_) => false);
+        print('[AuthWrapper] navigation finished');
       });
     }
   }
@@ -82,6 +86,8 @@ class _AuthWrapperState extends State<AuthWrapper> {
   // The mapping is documented in docs/roles.md for maintainability.
   String _resolveHomeRoute(AppUser user) {
     final perms = user.effectivePermissions;
+
+    print('[AuthWrapper] resolveHomeRoute for user ${user.id}');
 
     if (!(perms['canUseApp'] ?? false)) {
       return '/noAccess';

--- a/feature/extra_options/extra_options_screen.dart
+++ b/feature/extra_options/extra_options_screen.dart
@@ -6,6 +6,7 @@ class ExtraOptionsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[ExtraOptionsScreen] build');
     return ResponsiveScaffold(
       appBar: AppBar(
         title: const Text('Dodatkowe opcje'),

--- a/feature/grafik/form/grafik_element_form_screen.dart
+++ b/feature/grafik/form/grafik_element_form_screen.dart
@@ -22,6 +22,7 @@ class GrafikElementFormScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[GrafikElementFormScreen] build');
     return BlocProvider(
       create: (_) => GrafikElementFormCubit(
         grafikService: getIt<GrafikElementRepository>(),

--- a/feature/grafik/grafik_wrapper.dart
+++ b/feature/grafik/grafik_wrapper.dart
@@ -9,6 +9,7 @@ class GrafikWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[GrafikWrapper] build');
     return BlocBuilder<DateCubit, DateState>(
       builder: (context, dateState) {
         return SingleDayGrafikView(date: dateState.selectedDay);

--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -17,6 +17,7 @@ class SingleDayGrafikView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[SingleDayGrafikView] build');
     final selectedDay = context.watch<DateCubit>().state.selectedDay;
 
     return LayoutBuilder(

--- a/feature/grafik/widget/week/week_grafik_view.dart
+++ b/feature/grafik/widget/week/week_grafik_view.dart
@@ -16,6 +16,7 @@ class WeekGrafikView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[WeekGrafikView] build');
     return ResponsiveScaffold(
       appBar: GrafikAppBar(
         title: BlocBuilder<DateCubit, DateState>(

--- a/feature/main_menu/main_menu_screen.dart
+++ b/feature/main_menu/main_menu_screen.dart
@@ -7,6 +7,7 @@ class MainMenuScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[MainMenuScreen] build');
     final bp = context.breakpoint;
     final crossAxisCount = bp == Breakpoint.small
         ? 1

--- a/feature/my_tasks/assign_employee_screen.dart
+++ b/feature/my_tasks/assign_employee_screen.dart
@@ -38,6 +38,7 @@ class _MyTasksAssignEmployeeScreenState
 
   @override
   Widget build(BuildContext context) {
+    print('[MyTasksAssignEmployeeScreen] build');
     final employeeStream = GetIt.I<EmployeeRepository>().getEmployees();
     return ResponsiveScaffold(
       appBar: AppBar(title: const Text(AppStrings.assignEmployeeTitle)),

--- a/feature/my_tasks/my_tasks_screen.dart
+++ b/feature/my_tasks/my_tasks_screen.dart
@@ -20,6 +20,7 @@ class MyTasksScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[MyTasksScreen] build');
     final user = context.watch<AuthCubit>().currentUser;
     final day = context.watch<DateCubit>().state.selectedDay;
 

--- a/feature/supplies/supply_list_screen.dart
+++ b/feature/supplies/supply_list_screen.dart
@@ -11,6 +11,7 @@ class SupplyListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print('[SupplyListScreen] build');
     final repo = GetIt.instance<ISupplyRepository>();
     return ResponsiveScaffold(
       appBar: AppBar(

--- a/feature/supplies/supply_order_form.dart
+++ b/feature/supplies/supply_order_form.dart
@@ -28,6 +28,7 @@ class _SupplyOrderFormState extends State<SupplyOrderForm> {
 
   @override
   Widget build(BuildContext context) {
+    print('[SupplyOrderForm] build');
     return Scaffold(
       appBar: AppBar(
         title: Text('Zamów: ${widget.item.name}'),


### PR DESCRIPTION
## Summary
- log generated routes
- add extensive debug prints in `AuthCubit`
- print context details and navigation flow in `AuthWrapper`
- log builds of main screens

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687101025c088333a81cd9fb8b8a4c1b