### PR TITLE
Filter day view by user assignments

### DIFF
--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -11,9 +11,16 @@ import '../../../shared/custom_fab.dart';
 import '../../permission/permission_widget.dart'; // Dodaj ten import
 import '../../../shared/utils/date_formatting.dart';
 
-class SingleDayGrafikView extends StatelessWidget {
+class SingleDayGrafikView extends StatefulWidget {
   final DateTime date;
   const SingleDayGrafikView({Key? key, required this.date}) : super(key: key);
+
+  @override
+  State<SingleDayGrafikView> createState() => _SingleDayGrafikViewState();
+}
+
+class _SingleDayGrafikViewState extends State<SingleDayGrafikView> {
+  bool _showAll = false;
 
   @override
   Widget build(BuildContext context) {
@@ -57,26 +64,45 @@ class SingleDayGrafikView extends StatelessWidget {
                       },
                     ),
                   ),
-                  PermissionWidget(
-                    permission: 'canSeeWeeklySummary',
-                    child: IconButton(
-                      icon: const Icon(Icons.view_week),
-                      tooltip: AppStrings.weekView,
-                      onPressed: () {
-                        Navigator.pushNamed(context, '/weekGrafik');
+              PermissionWidget(
+                permission: 'canSeeWeeklySummary',
+                child: IconButton(
+                  icon: const Icon(Icons.view_week),
+                  tooltip: AppStrings.weekView,
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/weekGrafik');
+                  },
+                ),
+              ),
+              PermissionWidget(
+                permission: 'canSeeAllGrafik',
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(AppStrings.showAllGrafik),
+                    Switch(
+                      value: _showAll,
+                      onChanged: (v) {
+                        setState(() => _showAll = v);
                       },
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ],
           ),
-          body: ResponsivePadding(
+        ],
+      ),
+      body: ResponsivePadding(
             small: const EdgeInsets.all(AppSpacing.sm),
             medium: const EdgeInsets.all(AppSpacing.sm * 2),
             large: const EdgeInsets.all(AppSpacing.sm * 3),
-            child: TaskList(date: selectedDay, breakpoint: bp),
+          child: TaskList(
+            date: selectedDay,
+            breakpoint: bp,
+            showAll: _showAll,
           ),
+      ),
           floatingActionButton: PermissionWidget(
             permission: 'canAddGrafik',
             child: CustomFAB(

--- a/feature/grafik/widget/task/task_list.dart
+++ b/feature/grafik/widget/task/task_list.dart
@@ -5,6 +5,7 @@ import 'package:kabast/feature/permission/permission_widget.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/theme.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
+import '../../../auth/auth_cubit.dart';
 import '../../../../domain/models/grafik/enums.dart';
 import '../../cubit/grafik_cubit.dart';
 import '../../cubit/grafik_state.dart';
@@ -16,15 +17,29 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 class TaskList extends StatelessWidget {
   final DateTime date;
   final Breakpoint breakpoint;
+  final bool showAll;
 
-  const TaskList({Key? key, required this.date, required this.breakpoint})
-      : super(key: key);
+  const TaskList({
+    Key? key,
+    required this.date,
+    required this.breakpoint,
+    required this.showAll,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<GrafikCubit, GrafikState>(
       builder: (context, state) {
-        final tasks = state.tasks;
+        List<TaskElement> tasks = state.tasks;
+        if (!showAll) {
+          final currentUser = context.read<AuthCubit>().currentUser;
+          final userId = currentUser?.employeeId;
+          final assignedIds = state.assignments
+              .where((a) => a.workerId == userId)
+              .map((a) => a.taskId)
+              .toSet();
+          tasks = tasks.where((t) => assignedIds.contains(t.id)).toList();
+        }
         final employees = state.employees;
         final issues = state.issues;
 

--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -99,6 +99,7 @@ class AppStrings {
   static const gotoWeekGrafik = 'Widok tygodniowy'; // jeśli potrzebne
   static const dateRangePicker = 'Wybierz zakres dat';
   static const pickDate = 'Wybierz datę';
+  static const showAllGrafik = 'Pokaż cały grafik';
 
   static const zero = 'Zeruj';
   static const save = 'Zapisz';


### PR DESCRIPTION
## Summary
- allow toggling between personal and full schedule
- expose `_showAll` toggle in daily grafik app bar
- filter `TaskList` based on assignments when toggle disabled
- add string constant for the toggle label

## Testing
- `apt-get update` *(to check for dart tools)*

------
https://chatgpt.com/codex/tasks/task_e_68710f1c5e608333b526928df7444104