### PR TITLE
Add app drawer

### DIFF
--- a/feature/assign_employee/assign_employee_screen.dart
+++ b/feature/assign_employee/assign_employee_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../theme/app_tokens.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../../shared/form/custom_button.dart';
+import '../../shared/app_drawer.dart';
 import '../../data/repositories/employee_repository.dart';
 import '../auth/auth_cubit.dart';
 import "../../data/repositories/app_user_repository.dart";
@@ -55,6 +56,7 @@ class _AssignEmployeeScreenState extends State<AssignEmployeeScreen> {
   Widget build(BuildContext context) {
     final employeeStream = GetIt.I<EmployeeRepository>().getEmployees();
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(title: const Text(AppStrings.assignEmployeeTitle)),
       body: LayoutBuilder(
         builder: (context, constraints) {

--- a/feature/auth/screen/no_access_screen.dart
+++ b/feature/auth/screen/no_access_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kabast/shared/appbar/grafik_appbar.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/shared/app_drawer.dart';
 
 class NoAccessScreen extends StatelessWidget {
   const NoAccessScreen({super.key});
@@ -11,6 +12,7 @@ class NoAccessScreen extends StatelessWidget {
     final theme = Theme.of(context).textTheme;
 
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: GrafikAppBar(title: Text(AppStrings.noAccessTitle, style: theme.titleLarge)),
       body: Center(
         child: ResponsivePadding(

--- a/feature/extra_options/extra_options_screen.dart
+++ b/feature/extra_options/extra_options_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'package:kabast/shared/app_drawer.dart';
 
 class ExtraOptionsScreen extends StatelessWidget {
   const ExtraOptionsScreen({Key? key}) : super(key: key);
@@ -7,6 +8,7 @@ class ExtraOptionsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(
         title: const Text('Dodatkowe opcje'),
       ),

--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -10,6 +10,7 @@ import '../../../shared/appbar/grafik_appbar.dart';
 import '../../../shared/custom_fab.dart';
 import '../../permission/permission_widget.dart'; // Dodaj ten import
 import '../../../shared/utils/date_formatting.dart';
+import '../../../shared/app_drawer.dart';
 
 class SingleDayGrafikView extends StatelessWidget {
   final DateTime date;
@@ -27,6 +28,7 @@ class SingleDayGrafikView extends StatelessWidget {
         final bp = breakpointFromWidth(width);
 
         return ResponsiveScaffold(
+          drawer: const AppDrawer(),
           appBar: GrafikAppBar(
             title: Text(
               '${AppStrings.grafik}: ${formattedDate(selectedDay)}',

--- a/feature/grafik/widget/week/week_grafik_view.dart
+++ b/feature/grafik/widget/week/week_grafik_view.dart
@@ -10,6 +10,7 @@ import '../../../../shared/custom_fab.dart';
 import '../../../permission/permission_widget.dart';
 import '../../../date/date_cubit.dart';
 import '../../../date/date_state.dart';
+import '../../../../shared/app_drawer.dart';
 
 class WeekGrafikView extends StatelessWidget {
   const WeekGrafikView({super.key});
@@ -17,6 +18,7 @@ class WeekGrafikView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: GrafikAppBar(
         title: BlocBuilder<DateCubit, DateState>(
           builder: (context, dateState) {

--- a/feature/main_menu/main_menu_screen.dart
+++ b/feature/main_menu/main_menu_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../permission/permission_widget.dart';
+import '../../shared/app_drawer.dart';
 
 class MainMenuScreen extends StatelessWidget {
   const MainMenuScreen({Key? key}) : super(key: key);
@@ -61,6 +62,7 @@ class MainMenuScreen extends StatelessWidget {
     ];
 
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(title: const Text('Menu')),
       body: GridView.count(
         padding: const EdgeInsets.all(16),

--- a/feature/my_tasks/assign_employee_screen.dart
+++ b/feature/my_tasks/assign_employee_screen.dart
@@ -10,6 +10,7 @@ import '../employee/employee_picker.dart';
 import '../../shared/form/custom_button.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../../theme/app_tokens.dart';
+import '../../shared/app_drawer.dart';
 
 class MyTasksAssignEmployeeScreen extends StatefulWidget {
   const MyTasksAssignEmployeeScreen({super.key});
@@ -40,6 +41,7 @@ class _MyTasksAssignEmployeeScreenState
   Widget build(BuildContext context) {
     final employeeStream = GetIt.I<EmployeeRepository>().getEmployees();
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(title: const Text(AppStrings.assignEmployeeTitle)),
       body: LayoutBuilder(
         builder: (context, constraints) {

--- a/feature/my_tasks/my_tasks_screen.dart
+++ b/feature/my_tasks/my_tasks_screen.dart
@@ -14,6 +14,7 @@ import '../permission/permission_widget.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../../theme/app_tokens.dart';
 import '../../shared/utils/date_formatting.dart';
+import '../../shared/app_drawer.dart';
 
 class MyTasksScreen extends StatelessWidget {
   const MyTasksScreen({super.key});
@@ -31,6 +32,7 @@ class MyTasksScreen extends StatelessWidget {
 
     if (user.employeeId?.isEmpty ?? true) {
       return ResponsiveScaffold(
+        drawer: const AppDrawer(),
         appBar: AppBar(title: const Text('Moje zadania')),
         body: Center(
           child: Column(
@@ -90,6 +92,7 @@ class MyTasksScreen extends StatelessWidget {
     });
 
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(
         title: Text('Moje zadania: ${formattedDate(day)}'),
         actions: [

--- a/feature/supplies/supply_list_screen.dart
+++ b/feature/supplies/supply_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import '../../domain/models/supply_item.dart';
 import '../../domain/services/i_supply_repository.dart';
 import '../../shared/responsive/responsive_layout.dart';
+import '../../shared/app_drawer.dart';
 import 'supply_order_form.dart';
 
 class SupplyListScreen extends StatelessWidget {
@@ -13,6 +14,7 @@ class SupplyListScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final repo = GetIt.instance<ISupplyRepository>();
     return ResponsiveScaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(
         title: const Text('Zaopatrzenie'),
       ),

--- a/shared/app_drawer.dart
+++ b/shared/app_drawer.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../feature/auth/auth_cubit.dart';
+
+class AppDrawer extends StatelessWidget {
+  const AppDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: [
+          const DrawerHeader(
+            decoration: BoxDecoration(color: Colors.blueGrey),
+            child: Text('Menu'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.calendar_today),
+            title: const Text('Grafik dzienny'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.pushNamed(context, '/grafik');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.view_week),
+            title: const Text('Grafik tygodniowy'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.pushNamed(context, '/weekGrafik');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.inventory),
+            title: const Text('Zaopatrzenie'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.pushNamed(context, '/supplies');
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.logout),
+            title: const Text('Wyloguj'),
+            onTap: () {
+              Navigator.pop(context);
+              context.read<AuthCubit>().signOut();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/shared/appbar/grafik_appbar.dart
+++ b/shared/appbar/grafik_appbar.dart
@@ -25,28 +25,7 @@ class GrafikAppBar extends StatelessWidget implements PreferredSizeWidget {
         // Jeśli mamy dodatkowe akcje, dołącz je:
         if (actions != null) ...actions!,
 
-        // Menu nawigacji, widoczne dla użytkowników z uprawnieniem
-        // "canUseApp". Zapewnia szybki dostęp do kluczowych ekranów.
-        PermissionWidget(
-          permission: 'canUseApp',
-          child: PopupMenuButton<String>(
-            onSelected: (route) => Navigator.pushNamed(context, route),
-            itemBuilder: (context) => const [
-              PopupMenuItem(
-                value: '/grafik',
-                child: Text('Grafik dzienny'),
-              ),
-              PopupMenuItem(
-                value: '/weekGrafik',
-                child: Text('Grafik tygodniowy'),
-              ),
-              PopupMenuItem(
-                value: '/supplies',
-                child: Text('Zaopatrzenie'),
-              ),
-            ],
-          ),
-        ),
+
 
         // Przycisk WYLOGOWANIA – tylko jeśli ma uprawnienie
         PermissionWidget(

--- a/shared/index.dart
+++ b/shared/index.dart
@@ -3,3 +3,4 @@ export 'small_chip.dart';
 export 'form/standard/standard_form_field.dart';
 export 'form/standard/standard_form_section.dart';
 export 'utils/date_formatting.dart';
+export 'app_drawer.dart';


### PR DESCRIPTION
## Summary
- add an `AppDrawer` widget exporting menu routes and logout
- export the drawer from `shared/index.dart`
- show the drawer in all primary `ResponsiveScaffold` screens
- remove old popup menu from `GrafikAppBar`

## Testing
- `dart format --output=none --set-exit-if-changed lib` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710f2848e08333853f97baa021fa05