### PR TITLE
Add admin panel screen and route

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -11,6 +11,7 @@ import 'feature/supplies/supply_list_screen.dart';
 import 'feature/assign_employee/assign_employee_screen.dart';
 import 'feature/my_tasks/assign_employee_screen.dart';
 import 'feature/main_menu/main_menu_screen.dart';
+import 'feature/admin/admin_panel_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -40,6 +41,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const ExtraOptionsScreen());
       case '/supplies':
         return MaterialPageRoute(builder: (_) => const SupplyListScreen());
+      case '/admin':
+        return MaterialPageRoute(builder: (_) => const AdminPanelScreen());
       case '/addGrafik':
         final existingElement = settings.arguments as GrafikElement?;
         return MaterialPageRoute(

--- a/feature/admin/admin_panel_screen.dart
+++ b/feature/admin/admin_panel_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AdminPanelScreen extends StatelessWidget {
+  const AdminPanelScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Panel administracyjny'),
+      ),
+      body: const Center(
+        child: Text('Panel administracyjny'),
+      ),
+    );
+  }
+}

--- a/shared/app_drawer.dart
+++ b/shared/app_drawer.dart
@@ -40,6 +40,14 @@ class AppDrawer extends StatelessWidget {
               Navigator.pushNamed(context, '/supplies');
             },
           ),
+          ListTile(
+            leading: const Icon(Icons.admin_panel_settings),
+            title: const Text('Panel administracyjny'),
+            onTap: () {
+              Navigator.pop(context);
+              Navigator.pushNamed(context, '/admin');
+            },
+          ),
           const Divider(),
           ListTile(
             leading: const Icon(Icons.logout),


### PR DESCRIPTION
## Summary
- add new `AdminPanelScreen`
- register `/admin` route
- add admin panel entry to drawer

## Testing
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711a48f3b4833392a22080ebb44a97