### PR TITLE
Use themed color for supply list warnings

### DIFF
--- a/feature/supplies/supply_list_screen.dart
+++ b/feature/supplies/supply_list_screen.dart
@@ -50,7 +50,12 @@ class SupplyListScreen extends StatelessWidget {
   Widget _buildItemTile(BuildContext context, SupplyItem item) {
     final isLow = item.isLowStock;
     return ListTile(
-      leading: isLow ? const Icon(Icons.warning, color: Colors.red) : null,
+      leading: isLow
+          ? Icon(
+              Icons.warning,
+              color: Theme.of(context).colorScheme.error,
+            )
+          : null,
       title: Text(item.name),
       subtitle: Text('${item.quantityAvailable} ${item.unit}'),
       trailing: TextButton(


### PR DESCRIPTION
## Summary
- replace hard-coded `Colors.red` with `Theme.of(context).colorScheme.error`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68711a5f3b3483339a9ba0f4c50b1fbf