### PR TITLE
Improve grafik app bar title

### DIFF
--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -23,6 +23,9 @@ class SingleDayGrafikView extends StatefulWidget {
 class _SingleDayGrafikViewState extends State<SingleDayGrafikView> {
   bool _showAll = false;
 
+  bool _sameDate(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
   @override
   Widget build(BuildContext context) {
     final selectedDay = context.watch<DateCubit>().state.selectedDay;
@@ -38,12 +41,18 @@ class _SingleDayGrafikViewState extends State<SingleDayGrafikView> {
           drawer: const AppDrawer(),
           appBar: GrafikAppBar(
             title: Text(
-              '${AppStrings.grafik}: ${formattedDate(selectedDay)}',
+              grafikTitleDate(selectedDay),
               style: AppTheme.textStyleFor(
                 bp,
                 Theme.of(context).textTheme.titleLarge!,
               ),
             ),
+            backgroundColor: _sameDate(selectedDay, DateTime.now())
+                ? Theme.of(context).colorScheme.secondaryContainer
+                : null,
+            foregroundColor: _sameDate(selectedDay, DateTime.now())
+                ? Theme.of(context).colorScheme.onSecondaryContainer
+                : null,
             actions: [
               Wrap(
                 spacing: AppSpacing.sm,

--- a/shared/appbar/grafik_appbar.dart
+++ b/shared/appbar/grafik_appbar.dart
@@ -7,11 +7,15 @@ import '../../feature/permission/permission_widget.dart';
 class GrafikAppBar extends StatelessWidget implements PreferredSizeWidget {
   final Widget title;
   final List<Widget>? actions;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
 
   const GrafikAppBar({
     Key? key,
     required this.title,
     this.actions,
+    this.backgroundColor,
+    this.foregroundColor,
   }) : super(key: key);
 
   @override
@@ -21,6 +25,8 @@ class GrafikAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return AppBar(
       title: title,
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
       actions: [
         // Jeśli mamy dodatkowe akcje, dołącz je:
         if (actions != null) ...actions!,

--- a/shared/utils/date_formatting.dart
+++ b/shared/utils/date_formatting.dart
@@ -35,3 +35,32 @@ String formattedDate(DateTime date) {
 
   return '$day.$month - $name${suffix.isNotEmpty ? ' $suffix' : ''}';
 }
+
+/// Returns a short string like "10.07 - śr - dzisiaj" for the app bar title.
+String grafikTitleDate(DateTime? date) {
+  if (date == null) return '';
+
+  final day = date.day.toString().padLeft(2, '0');
+  final month = date.month.toString().padLeft(2, '0');
+
+  const shortNames = ['pn', 'wt', 'śr', 'czw', 'pt', 'sb', 'nd'];
+  final shortName = shortNames[date.weekday - 1];
+
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+  final tomorrow = today.add(const Duration(days: 1));
+
+  String suffix = '';
+  if (_isSameDate(date, yesterday)) {
+    suffix = 'wczoraj';
+  } else if (_isSameDate(date, today)) {
+    suffix = 'dzisiaj';
+  } else if (_isSameDate(date, tomorrow)) {
+    suffix = 'jutro';
+  }
+
+  return suffix.isEmpty
+      ? '$day.$month - $shortName'
+      : '$day.$month - $shortName - $suffix';
+}


### PR DESCRIPTION
## Summary
- add grafikTitleDate helper for short formatted dates with relative suffix
- allow GrafikAppBar to specify background and foreground colors
- update SingleDayGrafikView to show date like "10.07 - śr - dzisiaj" and highlight today

## Testing
- `dart format` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687132a9fd308333bfefb5f3d48d58ba