### PR TITLE
Add calendar actions and remove logout

### DIFF
--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -61,17 +61,41 @@ class _SingleDayGrafikViewState extends State<SingleDayGrafikView> {
                     permission: 'canChangeDate',
                     child: IconButton(
                       icon: const Icon(Icons.calendar_today),
+                      color: Theme.of(context).colorScheme.onPrimary,
                       onPressed: () async {
-                        final now = DateTime.now();
                         final picked = await showDatePicker(
                           context: context,
                           initialDate: selectedDay,
-                          firstDate: DateTime(now.year - 2),
-                          lastDate: DateTime(now.year + 2),
+                          firstDate: DateTime(2023),
+                          lastDate: DateTime(2030),
                         );
                         if (picked != null) {
                           context.read<DateCubit>().changeSelectedDay(picked);
                         }
+                      },
+                    ),
+                  ),
+                  PermissionWidget(
+                    permission: 'canChangeDate',
+                    child: IconButton(
+                      icon: const Icon(Icons.arrow_left),
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      onPressed: () {
+                        context
+                            .read<DateCubit>()
+                            .changeSelectedDay(selectedDay.subtract(const Duration(days: 1)));
+                      },
+                    ),
+                  ),
+                  PermissionWidget(
+                    permission: 'canChangeDate',
+                    child: IconButton(
+                      icon: const Icon(Icons.arrow_right),
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      onPressed: () {
+                        context
+                            .read<DateCubit>()
+                            .changeSelectedDay(selectedDay.add(const Duration(days: 1)));
                       },
                     ),
                   ),

--- a/shared/appbar/grafik_appbar.dart
+++ b/shared/appbar/grafik_appbar.dart
@@ -33,18 +33,6 @@ class GrafikAppBar extends StatelessWidget implements PreferredSizeWidget {
 
 
 
-        // Przycisk WYLOGOWANIA – tylko jeśli ma uprawnienie
-        PermissionWidget(
-          permission: 'canLogout',
-          child: IconButton(
-            icon: const Icon(Icons.logout),
-            tooltip: 'Wyloguj',
-            onPressed: () {
-              context.read<AuthCubit>().signOut();
-            },
-          ),
-        ),
-
         // Przycisk USTAWIEŃ – tylko jeśli ma uprawnienie
         PermissionWidget(
           permission: 'canEditSettings',


### PR DESCRIPTION
## Summary
- add calendar picker and navigation buttons to the single day grafik view
- remove the obsolete logout button from `GrafikAppBar`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687137955d948333975f70a8992ad3dd