### PR TITLE
Apply unified navy color scheme

### DIFF
--- a/shared/app_drawer.dart
+++ b/shared/app_drawer.dart
@@ -15,7 +15,7 @@ class AppDrawer extends StatelessWidget {
         children: [
           AppBar(
             automaticallyImplyLeading: false,
-            backgroundColor: colorScheme.primaryContainer,
+            backgroundColor: colorScheme.primary,
             centerTitle: true,
             title: Image.asset(
               'assets/images/logo_gradient.png',
@@ -24,7 +24,7 @@ class AppDrawer extends StatelessWidget {
             actions: [
               IconButton(
                 icon: const Icon(Icons.logout),
-                color: colorScheme.onPrimaryContainer,
+                color: colorScheme.onPrimary,
                 onPressed: () {
                   Navigator.pop(context);
                   context.read<AuthCubit>().signOut();
@@ -37,6 +37,8 @@ class AppDrawer extends StatelessWidget {
               padding: EdgeInsets.zero,
               children: [
                 ListTile(
+                  hoverColor: colorScheme.primaryContainer,
+                  selectedTileColor: colorScheme.primaryContainer,
                   leading: Icon(Icons.calendar_today, color: colorScheme.primary),
                   title: Text('Grafik dzienny', style: TextStyle(color: colorScheme.onSurface)),
                   onTap: () {
@@ -45,6 +47,8 @@ class AppDrawer extends StatelessWidget {
                   },
                 ),
                 ListTile(
+                  hoverColor: colorScheme.primaryContainer,
+                  selectedTileColor: colorScheme.primaryContainer,
                   leading: Icon(Icons.view_week, color: colorScheme.primary),
                   title: Text('Grafik tygodniowy', style: TextStyle(color: colorScheme.onSurface)),
                   onTap: () {
@@ -53,6 +57,8 @@ class AppDrawer extends StatelessWidget {
                   },
                 ),
                 ListTile(
+                  hoverColor: colorScheme.primaryContainer,
+                  selectedTileColor: colorScheme.primaryContainer,
                   leading: Icon(Icons.inventory, color: colorScheme.primary),
                   title: Text('Zaopatrzenie', style: TextStyle(color: colorScheme.onSurface)),
                   onTap: () {
@@ -61,6 +67,8 @@ class AppDrawer extends StatelessWidget {
                   },
                 ),
                 ListTile(
+                  hoverColor: colorScheme.primaryContainer,
+                  selectedTileColor: colorScheme.primaryContainer,
                   leading: Icon(Icons.admin_panel_settings, color: colorScheme.primary),
                   title: Text('Panel administracyjny', style: TextStyle(color: colorScheme.onSurface)),
                   onTap: () {

--- a/theme/color_schemes.dart
+++ b/theme/color_schemes.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+const primary = Color(0xFF0D47A1);
+const primaryContainer = Color(0xFF5472D3);
+const onPrimary = Colors.white;
+
+final lightColorScheme = ColorScheme.fromSeed(
+  seedColor: primary,
+  brightness: Brightness.light,
+);

--- a/theme/theme.dart
+++ b/theme/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'app_tokens.dart';
+import 'color_schemes.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class AppTheme {
@@ -30,23 +31,22 @@ class AppTheme {
     final width = view.physicalSize.width / view.devicePixelRatio;
     final scale = (width / 400).clamp(0.8, 1.2);
 
+    final scheme = lightColorScheme;
     return ThemeData(
       useMaterial3: false,
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: const Color(0xFF1565C0),
-        brightness: Brightness.light,
-      ),
+      colorScheme: scheme,
       scaffoldBackgroundColor: Colors.white,
 
       appBarTheme: AppBarTheme(
-        backgroundColor: Colors.white,
+        backgroundColor: scheme.primary,
+        foregroundColor: scheme.onPrimary,
         titleTextStyle: TextStyle(
           fontSize: 16 * scale,
           fontWeight: FontWeight.w600,
-          color: const Color(0xFF1565C0),
+          color: scheme.onPrimary,
         ),
-        iconTheme: const IconThemeData(color: Color(0xFF1565C0)),
-        actionsIconTheme: const IconThemeData(color: Color(0xFF1565C0)),
+        iconTheme: IconThemeData(color: scheme.onPrimary),
+        actionsIconTheme: IconThemeData(color: scheme.onPrimary),
         elevation: 2,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppRadius.md),
@@ -109,16 +109,16 @@ class AppTheme {
         padding: EdgeInsets.zero,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppRadius.md),
-          side: const BorderSide(
-            color: Color(0xFF1565C0),
+          side: BorderSide(
+            color: scheme.primary,
             width: 0.5,
           ),
         ),
-        selectedColor: const Color(0xFF64B5F6),
+        selectedColor: scheme.primaryContainer,
         backgroundColor: Colors.grey.shade200,
         labelStyle: TextStyle(
           fontSize: 16 * scale,
-          color: const Color(0xFF1565C0),
+          color: scheme.primary,
         ),
       ),
 
@@ -127,11 +127,11 @@ class AppTheme {
         contentPadding: const EdgeInsets.all(AppSpacing.sm),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppRadius.md),
-          borderSide: BorderSide(color: Color(0xFF1565C0),)
+          borderSide: BorderSide(color: scheme.primary,)
         ),
       ),
       floatingActionButtonTheme: FloatingActionButtonThemeData(
-        backgroundColor: const Color(0xFF64B5F6),
+        backgroundColor: scheme.primaryContainer,
         foregroundColor: Colors.white,
         elevation: 4,
       ),


### PR DESCRIPTION
## Summary
- introduce `color_schemes.dart` with navy palette
- update `AppTheme` to use the new `lightColorScheme`
- style the drawer AppBar and tiles with the new scheme

## Testing
- `dart format .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713ba4e3f08333b2feffa7c042d9d0