### PR TITLE
Add responsive EmployeeChip widget

### DIFF
--- a/feature/grafik/widget/task/employee_chip_list.dart
+++ b/feature/grafik/widget/task/employee_chip_list.dart
@@ -3,6 +3,7 @@ import 'package:kabast/domain/models/employee.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/theme.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'package:kabast/shared/employee_chip.dart';
 
 class EmployeeChipList extends StatelessWidget {
   final Iterable<Employee> employees;
@@ -20,57 +21,12 @@ class EmployeeChipList extends StatelessWidget {
       child: Wrap(
         spacing: AppTheme.sizeFor(context.breakpoint, 4),
         runSpacing: AppTheme.sizeFor(context.breakpoint, 4),
-        children: employees.map((e) => _buildChip(context, e)).toList(),
-      ),
-    );
-  }
-
-  Widget _buildChip(BuildContext context, Employee e) {
-    final name = e.formattedNameWithSecondInitial;
-    final parts = name.split(' ');
-    final surname = parts.first;
-    final rest = name.substring(surname.length);
-
-    return Chip(
-      label: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: RichText(
-          text: TextSpan(
-            children: [
-              TextSpan(
-                text: surname.substring(0, 1),
-                style: AppTheme.textStyleFor(
-                  context.breakpoint,
-                  Theme.of(context).textTheme.bodyLarge!.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: Colors.black,
-                      ),
-                ),
-              ),
-              TextSpan(
-                text: surname.substring(1) + rest,
-                style: AppTheme.textStyleFor(
-                  context.breakpoint,
-                  Theme.of(context).textTheme.bodyLarge!.copyWith(
-                        fontWeight: FontWeight.normal,
-                        color: Colors.black,
-                      ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-      padding: EdgeInsets.symmetric(
-        horizontal: AppTheme.sizeFor(context.breakpoint, 2),
-        vertical: AppTheme.sizeFor(context.breakpoint, 1),
-      ),
-      labelPadding: EdgeInsets.zero,
-      visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      backgroundColor: Colors.grey.shade200,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(4),
+        children: employees
+            .map((e) => EmployeeChip(
+                  employee: e,
+                  showFullName: context.breakpoint != Breakpoint.small,
+                ))
+            .toList(),
       ),
     );
   }

--- a/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
@@ -8,6 +8,9 @@ import 'package:kabast/theme/app_tokens.dart';
 import '../../../../../shared/turbo_grid/turbo_tile.dart';
 import '../../../../../shared/turbo_grid/widgets/clock_view_delegate.dart';
 import '../../../../../shared/turbo_grid/widgets/simple_text_delegate.dart';
+import '../../../../../shared/employee_chip.dart';
+import '../../../../../shared/responsive/responsive_layout.dart';
+import '../../../../../domain/models/employee.dart';
 import '../../dialog/grafik_element_popup.dart';
 
 class TimeIssueWeekTile extends StatelessWidget {
@@ -15,20 +18,16 @@ class TimeIssueWeekTile extends StatelessWidget {
 
   const TimeIssueWeekTile({Key? key, required this.timeIssue}) : super(key: key);
 
-  String _formatEmployeeName(String fullName) {
-    final parts = fullName.split(' ');
-    if (parts.length >= 2) return '${parts[0]} ${parts[1][0]}.';
-    return fullName;
+  List<Employee> _employeesFromIds(BuildContext context, List<String> ids) {
+    final state = context.read<GrafikCubit>().state;
+    return state.employees
+        .where((employee) => ids.contains(employee.uid))
+        .toList();
   }
 
-  String _buildEmployeeNames(BuildContext context, List<String> employeeIds) {
-    final state = context.read<GrafikCubit>().state;
-    final filteredEmployees = state.employees
-        .where((employee) => employeeIds.contains(employee.uid))
-        .toList();
-    return filteredEmployees
-        .map((employee) => _formatEmployeeName(employee.fullName))
-        .join(", ");
+  TurboTileDelegate _employeeDelegate(BuildContext context) {
+    final employees = _employeesFromIds(context, [timeIssue.workerId]);
+    return _EmployeeChipRowDelegate(employees);
   }
 
   Color _backgroundColor(BuildContext context) {
@@ -70,9 +69,7 @@ class TimeIssueWeekTile extends StatelessWidget {
                   TurboTile(
                     priority: 2,
                     required: true,
-                    delegate: SimpleTextDelegate(
-                      text: _buildEmployeeNames(context, [timeIssue.workerId]),
-                    ),
+                    delegate: _employeeDelegate(context),
                   ),
                   // 4. Powód
                   TurboTile(
@@ -90,4 +87,34 @@ class TimeIssueWeekTile extends StatelessWidget {
       ),
     );
   }
+}
+
+class _EmployeeChipRowDelegate extends TurboTileDelegate {
+  final List<Employee> employees;
+
+  _EmployeeChipRowDelegate(this.employees);
+
+  @override
+  List<TurboTileVariant> createVariants() => [
+        _variant(SizeVariant.big, 80.0 * employees.length),
+        _variant(SizeVariant.medium, 70.0 * employees.length),
+        _variant(SizeVariant.small, 60.0 * employees.length),
+      ];
+
+  TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
+        size: Size(width, v.height),
+        builder: (context) => SizedBox(
+          height: v.height,
+          child: Wrap(
+            spacing: AppTheme.sizeFor(context.breakpoint, 4),
+            runSpacing: AppTheme.sizeFor(context.breakpoint, 4),
+            children: employees
+                .map((e) => EmployeeChip(
+                      employee: e,
+                      showFullName: context.breakpoint != Breakpoint.small,
+                    ))
+                .toList(),
+          ),
+        ),
+      );
 }

--- a/shared/employee_chip.dart
+++ b/shared/employee_chip.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:kabast/domain/models/employee.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/theme.dart';
+
+class EmployeeChip extends StatelessWidget {
+  final Employee employee;
+  final bool? showFullName;
+
+  const EmployeeChip({super.key, required this.employee, this.showFullName});
+
+  @override
+  Widget build(BuildContext context) {
+    final bp = context.breakpoint;
+    final bool full = showFullName ?? bp != Breakpoint.small;
+
+    if (full) {
+      final name = employee.formattedNameWithSecondInitial;
+      final parts = name.split(' ');
+      final surname = parts.first;
+      final rest = name.substring(surname.length);
+      return Chip(
+        label: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: RichText(
+            text: TextSpan(
+              children: [
+                TextSpan(
+                  text: surname.substring(0, 1),
+                  style: AppTheme.textStyleFor(
+                    bp,
+                    Theme.of(context).textTheme.bodyLarge!.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black,
+                        ),
+                  ),
+                ),
+                TextSpan(
+                  text: surname.substring(1) + rest,
+                  style: AppTheme.textStyleFor(
+                    bp,
+                    Theme.of(context).textTheme.bodyLarge!.copyWith(
+                          fontWeight: FontWeight.normal,
+                          color: Colors.black,
+                        ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        padding: EdgeInsets.symmetric(
+          horizontal: AppTheme.sizeFor(bp, 2),
+          vertical: AppTheme.sizeFor(bp, 1),
+        ),
+        labelPadding: EdgeInsets.zero,
+        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        backgroundColor: Colors.grey.shade200,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(4),
+        ),
+      );
+    } else {
+      final initials = employee.fullName
+          .split(' ')
+          .where((e) => e.isNotEmpty)
+          .map((e) => e[0])
+          .take(2)
+          .join();
+      return Chip(
+        padding: EdgeInsets.all(AppTheme.sizeFor(bp, 1)),
+        labelPadding: EdgeInsets.zero,
+        visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        label: Text(
+          initials,
+          style: AppTheme.textStyleFor(
+            bp,
+            Theme.of(context).textTheme.bodySmall!.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+          ),
+        ),
+        backgroundColor: Colors.grey.shade200,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+        ),
+      );
+    }
+  }
+}

--- a/shared/index.dart
+++ b/shared/index.dart
@@ -1,5 +1,6 @@
 export 'custom_fab.dart';
 export 'small_chip.dart';
+export 'employee_chip.dart';
 export 'form/standard/standard_form_field.dart';
 export 'form/standard/standard_form_section.dart';
 export 'utils/date_formatting.dart';


### PR DESCRIPTION
## Summary
- create `EmployeeChip` widget to show full or initial-only chips based on breakpoint
- update `EmployeeChipList` to use the new widget
- replace employee text in `TimeIssueWeekTile` with responsive chips
- export new component from `shared/index.dart`

## Testing
- ❌ `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687149fb45248333b391ece79197e07a