### PR TITLE
Introduce TileSizeResolver for shared layout sizing

### DIFF
--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -68,8 +68,7 @@ class _TaskCardDelegate extends TurboTileDelegate {
         height: height,
         child: TaskCard(
           task: task,
-          showEmployees: v != SizeVariant.small,
-          showVehicles: v != SizeVariant.small,
+          variant: v,
         ),
       ),
     );

--- a/shared/task_card.dart
+++ b/shared/task_card.dart
@@ -7,6 +7,8 @@ import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/theme.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'package:kabast/theme/size_variants.dart';
+import 'utils/tile_size_resolver.dart';
 import '../feature/grafik/widget/task/employee_chip_list.dart';
 import '../feature/grafik/widget/task/vehicle_list.dart';
 
@@ -14,12 +16,14 @@ class TaskCard extends StatelessWidget {
   final TaskElement task;
   final bool showEmployees;
   final bool showVehicles;
+  final SizeVariant? variant;
 
   const TaskCard({
     Key? key,
     required this.task,
     this.showEmployees = true,
     this.showVehicles = true,
+    this.variant,
   }) : super(key: key);
 
   static const _typeIcons = {
@@ -34,68 +38,80 @@ class TaskCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final state = context.watch<GrafikCubit>().state;
-    final assignedIds = state.assignments
-        .where((a) => a.taskId == task.id)
-        .map((a) => a.workerId)
-        .toSet();
-    final employees = state.employees.where((e) => assignedIds.contains(e.uid));
-    final vehicles = state.vehicles.where((v) => task.carIds.contains(v.id));
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final sizeVariant =
+            variant ?? TileSizeResolver.resolve(width: constraints.maxWidth);
 
-    final typeIcon = _typeIcons[task.taskType] ?? Icons.task;
-    final statusIcon = task.status.icon;
+        final state = context.watch<GrafikCubit>().state;
+        final assignedIds = state.assignments
+            .where((a) => a.taskId == task.id)
+            .map((a) => a.workerId)
+            .toSet();
+        final employees =
+            state.employees.where((e) => assignedIds.contains(e.uid));
+        final vehicles =
+            state.vehicles.where((v) => task.carIds.contains(v.id));
 
-    return Card(
-      margin: const EdgeInsets.all(AppSpacing.xs),
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.sm),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
+        final typeIcon = _typeIcons[task.taskType] ?? Icons.task;
+        final statusIcon = task.status.icon;
+
+        final showEmps = showEmployees && sizeVariant != SizeVariant.small;
+        final showVehs = showVehicles && sizeVariant != SizeVariant.small;
+
+        return Card(
+          margin: const EdgeInsets.all(AppSpacing.xs),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(typeIcon,
-                    size: AppTheme.sizeFor(context.breakpoint, 24)),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: Text(
-                    task.additionalInfo,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTheme.textStyleFor(
-                      context.breakpoint,
-                      Theme.of(context)
-                          .textTheme
-                          .bodyLarge!
-                          .copyWith(fontWeight: FontWeight.bold),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(typeIcon,
+                        size: AppTheme.sizeFor(context.breakpoint, 24)),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: Text(
+                        task.additionalInfo,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTheme.textStyleFor(
+                          context.breakpoint,
+                          Theme.of(context)
+                              .textTheme
+                              .bodyLarge!
+                              .copyWith(fontWeight: FontWeight.bold),
+                        ),
+                      ),
                     ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Icon(statusIcon,
+                        size: AppTheme.sizeFor(context.breakpoint, 24)),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${_fmt(task.startDateTime)} - ${_fmt(task.endDateTime)}',
+                  style: AppTheme.textStyleFor(
+                    context.breakpoint,
+                    Theme.of(context).textTheme.bodyMedium!,
                   ),
                 ),
-                const SizedBox(width: AppSpacing.sm),
-                Icon(statusIcon,
-                    size: AppTheme.sizeFor(context.breakpoint, 24)),
+                if (showEmps && employees.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  EmployeeChipList(employees: employees),
+                ],
+                if (showVehs && vehicles.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  VehicleList(vehicleIds: task.carIds),
+                ],
               ],
             ),
-            const SizedBox(height: 4),
-            Text(
-              '${_fmt(task.startDateTime)} - ${_fmt(task.endDateTime)}',
-              style: AppTheme.textStyleFor(
-                context.breakpoint,
-                Theme.of(context).textTheme.bodyMedium!,
-              ),
-            ),
-            if (showEmployees && employees.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              EmployeeChipList(employees: employees),
-            ],
-            if (showVehicles && vehicles.isNotEmpty) ...[
-              const SizedBox(height: 4),
-              VehicleList(vehicleIds: task.carIds),
-            ],
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/shared/utils/tile_size_resolver.dart
+++ b/shared/utils/tile_size_resolver.dart
@@ -1,0 +1,41 @@
+import '../responsive/responsive_layout.dart';
+import '../../theme/size_variants.dart';
+
+/// Determines [SizeVariant] for tiles based on available space.
+class TileSizeResolver {
+  static const double _bigWidthThreshold = 300;
+  static const double _mediumWidthThreshold = 260;
+
+  static const double _bigHeightThreshold = 44;
+  static const double _mediumHeightThreshold = 28;
+
+  /// Returns the [SizeVariant] that should be used for a tile given
+  /// available width, height or breakpoint.
+  static SizeVariant resolve({
+    double? width,
+    double? height,
+    Breakpoint? breakpoint,
+  }) {
+    if (breakpoint != null) {
+      switch (breakpoint) {
+        case Breakpoint.large:
+          return SizeVariant.big;
+        case Breakpoint.medium:
+          return SizeVariant.medium;
+        case Breakpoint.small:
+          return SizeVariant.small;
+      }
+    }
+    if (width != null) {
+      if (width >= _bigWidthThreshold) return SizeVariant.big;
+      if (width >= _mediumWidthThreshold) return SizeVariant.medium;
+      return SizeVariant.small;
+    }
+    if (height != null) {
+      if (height >= _bigHeightThreshold) return SizeVariant.big;
+      if (height >= _mediumHeightThreshold) return SizeVariant.medium;
+      return SizeVariant.small;
+    }
+    return SizeVariant.small;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new helper `TileSizeResolver` for unified tile sizing
- make `TaskCard` use TileSizeResolver and expose a `variant` parameter
- hook week view tiles into the resolver via TaskCard

## Testing
- `dart` and `flutter` are not installed so no linting or tests were run

------
https://chatgpt.com/codex/tasks/task_e_68714a3700788333a77cb9d719ebe755