### PR TITLE
Refactor TaskWeekTile with GrafikElementCard

### DIFF
--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -5,6 +5,7 @@ import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/default_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/task_planning_week_tile.dart';
@@ -18,6 +19,21 @@ import 'grafik_grid.dart';
 
 class ForegroundLayer extends StatelessWidget {
   const ForegroundLayer({Key? key}) : super(key: key);
+
+  GrafikElementData _taskData(GrafikState state, TaskElement task) {
+    final assignments =
+        state.assignments.where((a) => a.taskId == task.id).toList();
+    final employees = state.employees
+        .where((e) => assignments.any((a) => a.workerId == e.uid))
+        .toList();
+    final vehicles =
+        state.vehicles.where((v) => task.carIds.contains(v.id)).toList();
+    return GrafikElementData(
+      assignedEmployees: employees,
+      assignedVehicles: vehicles,
+      assignments: assignments,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +60,10 @@ class ForegroundLayer extends StatelessWidget {
             } else if (elem is DeliveryPlanningElement) {
               return DeliveryPlanningWeekTile(deliveryPlanning: elem);
             } else if (elem is TaskElement) {
-              return TaskWeekTile(task: elem);
+              return TaskWeekTile(
+                task: elem,
+                data: _taskData(state, elem),
+              );
             } else if (elem is TimeIssueElement) {
               return TimeIssueWeekTile(timeIssue: elem);
             } else {

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -1,51 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
-import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
 import 'package:kabast/shared/turbo_grid/turbo_tile_delegate.dart';
 import 'package:kabast/shared/turbo_grid/turbo_tile_variant.dart';
-import 'package:kabast/shared/task_card.dart';
-import '../../../../../theme/app_tokens.dart';
 import '../../../../../theme/size_variants.dart';
-import '../../dialog/grafik_element_popup.dart';
-import '../../../constants/element_styles.dart';
 
 class TaskWeekTile extends StatelessWidget {
   final TaskElement task;
-  const TaskWeekTile({Key? key, required this.task}) : super(key: key);
+  final GrafikElementData data;
+
+  const TaskWeekTile({
+    Key? key,
+    required this.task,
+    required this.data,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final style = const GrafikElementStyleResolver().styleFor(task.type);
-    return GestureDetector(
-      onTap: () => showGrafikElementPopup(context, task),
-      child: Container(
-        decoration: BoxDecoration(
-          color: style.backgroundColor,
-          borderRadius: BorderRadius.circular(AppRadius.md),
+    return TurboGrid(
+      tiles: [
+        TurboTile(
+          priority: 1,
+          required: true,
+          delegate: _TaskCardDelegate(task, data),
         ),
-        padding: const EdgeInsets.all(AppSpacing.xs),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            return TurboGrid(
-              tiles: [
-                TurboTile(
-                  priority: 1,
-                  required: true,
-                  delegate: _TaskCardDelegate(task),
-                ),
-              ],
-            );
-          },
-        ),
-      ),
+      ],
     );
   }
 }
 
 class _TaskCardDelegate extends TurboTileDelegate {
   final TaskElement task;
-  _TaskCardDelegate(this.task);
+  final GrafikElementData data;
+
+  _TaskCardDelegate(this.task, this.data);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -66,8 +57,9 @@ class _TaskCardDelegate extends TurboTileDelegate {
       builder: (context) => SizedBox(
         width: width,
         height: height,
-        child: TaskCard(
-          task: task,
+        child: GrafikElementCard(
+          element: task,
+          data: data,
           variant: v,
         ),
       ),


### PR DESCRIPTION
## Summary
- pass `GrafikElementData` to `TaskWeekTile`
- build tile variants using `GrafikElementCard`
- compute task data in `ForegroundLayer`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871605d25048333b75a7fa4a5b4e16f