### PR TITLE
Refactor week tiles to use shared GrafikElementCard

### DIFF
--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -35,6 +35,29 @@ class ForegroundLayer extends StatelessWidget {
     );
   }
 
+  GrafikElementData _taskPlanningData(GrafikState state) {
+    return const GrafikElementData(
+      assignedEmployees: [],
+      assignedVehicles: [],
+    );
+  }
+
+  GrafikElementData _deliveryPlanningData(GrafikState state) {
+    return const GrafikElementData(
+      assignedEmployees: [],
+      assignedVehicles: [],
+    );
+  }
+
+  GrafikElementData _timeIssueData(GrafikState state, TimeIssueElement issue) {
+    final employees =
+        state.employees.where((e) => e.uid == issue.workerId).toList();
+    return GrafikElementData(
+      assignedEmployees: employees,
+      assignedVehicles: const [],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<GrafikCubit, GrafikState>(
@@ -56,16 +79,25 @@ class ForegroundLayer extends StatelessWidget {
           // fallback – nieużywany, gdy przekazany jest weekTileBuilder
           weekTileBuilder: (elem) {
             if (elem is TaskPlanningElement) {
-              return TaskPlanningWeekTile(taskPlanning: elem);
+              return TaskPlanningWeekTile(
+                taskPlanning: elem,
+                data: _taskPlanningData(state),
+              );
             } else if (elem is DeliveryPlanningElement) {
-              return DeliveryPlanningWeekTile(deliveryPlanning: elem);
+              return DeliveryPlanningWeekTile(
+                deliveryPlanning: elem,
+                data: _deliveryPlanningData(state),
+              );
             } else if (elem is TaskElement) {
               return TaskWeekTile(
                 task: elem,
                 data: _taskData(state, elem),
               );
             } else if (elem is TimeIssueElement) {
-              return TimeIssueWeekTile(timeIssue: elem);
+              return TimeIssueWeekTile(
+                timeIssue: elem,
+                data: _timeIssueData(state, elem),
+              );
             } else {
               return DefaultWeekTile(element: elem);
             }

--- a/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart
@@ -1,82 +1,67 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
-import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
-import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_delegate.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_variant.dart';
 
-import '../../../../../shared/turbo_grid/widgets/clock_view_delegate.dart';
-import '../../../../../shared/turbo_grid/widgets/simple_text_delegate.dart';
-import '../../dialog/grafik_element_popup.dart';
-import '../../../constants/element_styles.dart';
+import '../../../../../theme/size_variants.dart';
 
 class DeliveryPlanningWeekTile extends StatelessWidget {
   final DeliveryPlanningElement deliveryPlanning;
+  final GrafikElementData data;
 
-  const DeliveryPlanningWeekTile({Key? key, required this.deliveryPlanning})
-      : super(key: key);
+  const DeliveryPlanningWeekTile({
+    Key? key,
+    required this.deliveryPlanning,
+    required this.data,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final style = const GrafikElementStyleResolver().styleFor(deliveryPlanning.type);
-    return Padding(
-      padding: const EdgeInsets.all(AppSpacing.xs),
-      child: GestureDetector(
-        onTap: () => showGrafikElementPopup(context, deliveryPlanning),
-        child: Container(
-          decoration: BoxDecoration(
-            color: style.backgroundColor,
-            borderRadius: BorderRadius.circular(AppRadius.md),
-          ),
-          padding: const EdgeInsets.all(AppSpacing.xs),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              return TurboGrid(
-                tiles: [
-                  // 1. Zegar: czas od..do
-                  TurboTile(
-                    priority: 1,
-                    required: true,
-                    delegate: ClockViewDelegate(
-                      start: deliveryPlanning.startDateTime,
-                      end: deliveryPlanning.endDateTime,
-                    ),
-                  ),
-                  // 2. Additional info
-                  TurboTile(
-                    priority: 1,
-                    required: true,
-                    delegate: SimpleTextDelegate(
-                      text: deliveryPlanning.additionalInfo,
-                    ),
-                  ),
-                  // 3. Numer zamówienia
-                  TurboTile(
-                    priority: 3,
-                    required: true,
-                    delegate: SimpleTextDelegate(
-                      text: deliveryPlanning.orderId,
-                    ),
-                  ),
-                  // 4. Kategoria
-                  TurboTile(
-                    priority: 4,
-                    required: true,
-                    delegate: SimpleTextDelegate(
-                      text: deliveryPlanning.category.name,
-                    ),
-                  ),
-                  // 5. Tekst stały (opcjonalny)
-                  TurboTile(
-                    priority: 5,
-                    required: false,
-                    delegate: SimpleTextDelegate(
-                      text: "DeliveryPlanningElement",
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
+    return TurboGrid(
+      tiles: [
+        TurboTile(
+          priority: 1,
+          required: true,
+          delegate: _DeliveryPlanningCardDelegate(deliveryPlanning, data),
+        ),
+      ],
+    );
+  }
+}
+
+class _DeliveryPlanningCardDelegate extends TurboTileDelegate {
+  final DeliveryPlanningElement deliveryPlanning;
+  final GrafikElementData data;
+
+  _DeliveryPlanningCardDelegate(this.deliveryPlanning, this.data);
+
+  @override
+  List<TurboTileVariant> createVariants() => [
+        _variant(SizeVariant.big),
+        _variant(SizeVariant.medium),
+        _variant(SizeVariant.small),
+      ];
+
+  TurboTileVariant _variant(SizeVariant v) {
+    final width = switch (v) {
+      SizeVariant.big => 320.0,
+      SizeVariant.medium => 280.0,
+      SizeVariant.small => 240.0,
+    };
+    final height = v.height * 3;
+    return TurboTileVariant(
+      size: Size(width, height),
+      builder: (context) => SizedBox(
+        width: width,
+        height: height,
+        child: GrafikElementCard(
+          element: deliveryPlanning,
+          data: data,
+          variant: v,
         ),
       ),
     );

--- a/feature/grafik/widget/week/tiles/task_planning_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_planning_week_tile.dart
@@ -1,95 +1,67 @@
 import 'package:flutter/material.dart';
 import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
-import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
-import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_delegate.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_variant.dart';
 
-import '../../../../../shared/turbo_grid/widgets/clock_view_delegate.dart';
-import '../../../../../shared/turbo_grid/widgets/simple_text_delegate.dart';
-import '../../../../../shared/turbo_grid/widgets/work_time_planning_delegate.dart';
-import '../../dialog/grafik_element_popup.dart';
-import '../../../constants/element_styles.dart';
+import '../../../../../theme/size_variants.dart';
 
 class TaskPlanningWeekTile extends StatelessWidget {
   final TaskPlanningElement taskPlanning;
-  const TaskPlanningWeekTile({Key? key, required this.taskPlanning}) : super(key: key);
+  final GrafikElementData data;
+
+  const TaskPlanningWeekTile({
+    Key? key,
+    required this.taskPlanning,
+    required this.data,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final style = const GrafikElementStyleResolver().styleFor(taskPlanning.type);
-    return Padding(
-      padding: const EdgeInsets.all(AppSpacing.xs),
-      child: GestureDetector(
-        onTap: () => showGrafikElementPopup(context, taskPlanning),
-        child: Stack(
-          children: [
-            // ---------- główny kafelek ----------
-            Container(
-              decoration: BoxDecoration(
-                color: style.backgroundColor,
-                borderRadius: BorderRadius.circular(AppRadius.md),
-              ),
-              padding: const EdgeInsets.all(AppSpacing.xs),
-              child: LayoutBuilder(
-                builder: (context, constraints) => TurboGrid(
-                  tiles: [
-                    TurboTile(
-                      priority: 1,
-                      required: true,
-                      delegate: ClockViewDelegate(
-                        start: taskPlanning.startDateTime,
-                        end: taskPlanning.endDateTime,
-                      ),
-                    ),
-                    TurboTile(
-                      priority: 1,
-                      required: true,
-                      delegate: SimpleTextDelegate(text: taskPlanning.additionalInfo),
-                    ),
-                    TurboTile(
-                      priority: 2,
-                      required: false,
-                      delegate: SimpleTextDelegate(text: taskPlanning.orderId),
-                    ),
-                    TurboTile(
-                      priority: 3,
-                      required: false,
-                      delegate: SimpleTextDelegate(
-                        text: taskPlanning.probability.toString(),
-                      ),
-                    ),
-                    // UWAGA: to pole było tekstem – usuwamy,
-                    // bo teraz sygnalizujemy priorytet ikoną
-                    TurboTile(
-                      priority: 4,
-                      required: false,
-                      delegate: SimpleTextDelegate(text: taskPlanning.taskType.name),
-                    ),
-                    TurboTile(
-                      priority: 5,
-                      required: false,
-                      delegate: WorkTimePlanningDelegate(
-                        workerCount: taskPlanning.workerCount,
-                        minutes: taskPlanning.minutes,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+    return TurboGrid(
+      tiles: [
+        TurboTile(
+          priority: 1,
+          required: true,
+          delegate: _TaskPlanningCardDelegate(taskPlanning, data),
+        ),
+      ],
+    );
+  }
+}
 
-            // ---------- badge priorytetu ----------
-            if (taskPlanning.highPriority && style.badgeIcon != null)
-              Positioned(
-                bottom: 4,
-                right: 4,
-                child: Icon(
-                  style.badgeIcon,
-                  color: style.badgeColor,
-                  size: 18,
-                ),
-              ),
-          ],
+class _TaskPlanningCardDelegate extends TurboTileDelegate {
+  final TaskPlanningElement taskPlanning;
+  final GrafikElementData data;
+
+  _TaskPlanningCardDelegate(this.taskPlanning, this.data);
+
+  @override
+  List<TurboTileVariant> createVariants() => [
+        _variant(SizeVariant.big),
+        _variant(SizeVariant.medium),
+        _variant(SizeVariant.small),
+      ];
+
+  TurboTileVariant _variant(SizeVariant v) {
+    final width = switch (v) {
+      SizeVariant.big => 320.0,
+      SizeVariant.medium => 280.0,
+      SizeVariant.small => 240.0,
+    };
+    final height = v.height * 3;
+    return TurboTileVariant(
+      size: Size(width, height),
+      builder: (context) => SizedBox(
+        width: width,
+        height: height,
+        child: GrafikElementCard(
+          element: taskPlanning,
+          data: data,
+          variant: v,
         ),
       ),
     );

--- a/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
@@ -1,119 +1,69 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
-import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
 import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
-import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_delegate.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_variant.dart';
 
-import '../../../../../shared/turbo_grid/turbo_tile.dart';
-import '../../../../../shared/turbo_grid/widgets/clock_view_delegate.dart';
-import '../../../../../shared/turbo_grid/widgets/simple_text_delegate.dart';
-import '../../../../../shared/employee_chip.dart';
-import '../../../../../shared/responsive/responsive_layout.dart';
-import '../../../../../domain/models/employee.dart';
-import '../../dialog/grafik_element_popup.dart';
-import '../../../constants/element_styles.dart';
+import '../../../../../theme/size_variants.dart';
 
 class TimeIssueWeekTile extends StatelessWidget {
   final TimeIssueElement timeIssue;
+  final GrafikElementData data;
 
-  const TimeIssueWeekTile({Key? key, required this.timeIssue}) : super(key: key);
-
-  List<Employee> _employeesFromIds(BuildContext context, List<String> ids) {
-    final state = context.read<GrafikCubit>().state;
-    return state.employees
-        .where((employee) => ids.contains(employee.uid))
-        .toList();
-  }
-
-  TurboTileDelegate _employeeDelegate(BuildContext context) {
-    final employees = _employeesFromIds(context, [timeIssue.workerId]);
-    return _EmployeeChipRowDelegate(employees);
-  }
-
+  const TimeIssueWeekTile({
+    Key? key,
+    required this.timeIssue,
+    required this.data,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final style = const GrafikElementStyleResolver().styleFor(timeIssue.type);
-    return Padding(
-      padding: const EdgeInsets.all(AppSpacing.xs),
-      child: GestureDetector(
-        onTap: () => showGrafikElementPopup(context, timeIssue),
-        child: Container(
-          decoration: BoxDecoration(
-            color: style.backgroundColor,
-            borderRadius: BorderRadius.circular(AppRadius.md),
-          ),
-          padding: const EdgeInsets.all(AppSpacing.xs),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              return TurboGrid(
-                tiles: [
-                  // 1. Przedział czasu
-                  TurboTile(
-                    priority: 1,
-                    required: true,
-                    delegate: ClockViewDelegate(
-                      start: timeIssue.startDateTime,
-                      end: timeIssue.endDateTime,
-                    ),
-                  ),
-                  // 2. Additional Info
-                  TurboTile(
-                    priority: 1,
-                    required: true,
-                    delegate: SimpleTextDelegate(text: timeIssue.additionalInfo),
-                  ),
-                  // 3. Lista pracowników
-                  TurboTile(
-                    priority: 2,
-                    required: true,
-                    delegate: _employeeDelegate(context),
-                  ),
-                  // 4. Powód
-                  TurboTile(
-                    priority: 3,
-                    required: false,
-                    delegate: SimpleTextDelegate(
-                      text: timeIssue.issueType.name,
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
+    return TurboGrid(
+      tiles: [
+        TurboTile(
+          priority: 1,
+          required: true,
+          delegate: _TimeIssueCardDelegate(timeIssue, data),
         ),
-      ),
+      ],
     );
   }
 }
 
-class _EmployeeChipRowDelegate extends TurboTileDelegate {
-  final List<Employee> employees;
+class _TimeIssueCardDelegate extends TurboTileDelegate {
+  final TimeIssueElement timeIssue;
+  final GrafikElementData data;
 
-  _EmployeeChipRowDelegate(this.employees);
+  _TimeIssueCardDelegate(this.timeIssue, this.data);
 
   @override
   List<TurboTileVariant> createVariants() => [
-        _variant(SizeVariant.big, 80.0 * employees.length),
-        _variant(SizeVariant.medium, 70.0 * employees.length),
-        _variant(SizeVariant.small, 60.0 * employees.length),
+        _variant(SizeVariant.big),
+        _variant(SizeVariant.medium),
+        _variant(SizeVariant.small),
       ];
 
-  TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
-        size: Size(width, v.height),
-        builder: (context) => SizedBox(
-          height: v.height,
-          child: Wrap(
-            spacing: AppTheme.sizeFor(context.breakpoint, 4),
-            runSpacing: AppTheme.sizeFor(context.breakpoint, 4),
-            children: employees
-                .map((e) => EmployeeChip(
-                      employee: e,
-                      showFullName: context.breakpoint != Breakpoint.small,
-                    ))
-                .toList(),
-          ),
+  TurboTileVariant _variant(SizeVariant v) {
+    final width = switch (v) {
+      SizeVariant.big => 320.0,
+      SizeVariant.medium => 280.0,
+      SizeVariant.small => 240.0,
+    };
+    final height = v.height * 3;
+    return TurboTileVariant(
+      size: Size(width, height),
+      builder: (context) => SizedBox(
+        width: width,
+        height: height,
+        child: GrafikElementCard(
+          element: timeIssue,
+          data: data,
+          variant: v,
         ),
-      );
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- simplify DeliveryPlanningWeekTile, TaskPlanningWeekTile and TimeIssueWeekTile
- centralize tile data build logic in ForegroundLayer
- use GrafikElementCard via TurboTile delegates for all week tiles

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871680d800083338cc6d04210ab5c61