### PR TITLE
Refactor daily task cards to use GrafikElementCard

### DIFF
--- a/feature/grafik/widget/task/task_list.dart
+++ b/feature/grafik/widget/task/task_list.dart
@@ -6,13 +6,14 @@ import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/theme.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 import '../../../auth/auth_cubit.dart';
-import '../../../../domain/models/grafik/enums.dart';
 import '../../cubit/grafik_cubit.dart';
 import '../../cubit/grafik_state.dart';
 import '../../form/standard_task_row.dart';
 import 'employee_daily_summary.dart';
-import 'package:kabast/shared/task_card.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/utils/tile_size_resolver.dart';
 
 class TaskList extends StatelessWidget {
   final DateTime date;
@@ -108,9 +109,34 @@ class TaskList extends StatelessWidget {
                   childAspectRatio: 3,
                 ),
                 itemCount: nonStandardTasks.length,
-                itemBuilder: (context, index) => TaskCard(
-                  task: nonStandardTasks[index],
-                ),
+                itemBuilder: (context, index) {
+                  final task = nonStandardTasks[index];
+                  final assignments = state.assignments
+                      .where((a) => a.taskId == task.id)
+                      .toList();
+                  final employees = state.employees
+                      .where((e) => assignments.any((a) => a.workerId == e.uid))
+                      .toList();
+                  final vehicles = state.vehicles
+                      .where((v) => task.carIds.contains(v.id))
+                      .toList();
+                  final data = GrafikElementData(
+                    assignedEmployees: employees,
+                    assignedVehicles: vehicles,
+                    assignments: assignments,
+                  );
+                  return LayoutBuilder(
+                    builder: (context, constraints) {
+                      final variant = TileSizeResolver.resolve(
+                          width: constraints.maxWidth);
+                      return GrafikElementCard(
+                        element: task,
+                        data: data,
+                        variant: variant,
+                      );
+                    },
+                  );
+                },
               ),
             ),
           );

--- a/shared/task_card.dart
+++ b/shared/task_card.dart
@@ -1,40 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
-import 'package:kabast/domain/models/grafik/enums.dart';
-import 'package:kabast/feature/grafik/constants/enums_ui.dart';
-import 'package:kabast/feature/grafik/cubit/grafik_cubit.dart';
-import 'package:kabast/theme/app_tokens.dart';
-import 'package:kabast/theme/theme.dart';
-import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
 import 'package:kabast/theme/size_variants.dart';
 import 'utils/tile_size_resolver.dart';
-import '../feature/grafik/widget/task/employee_chip_list.dart';
-import '../feature/grafik/widget/task/vehicle_list.dart';
+import 'grafik_element_card.dart';
 
 class TaskCard extends StatelessWidget {
   final TaskElement task;
-  final bool showEmployees;
-  final bool showVehicles;
+  final GrafikElementData data;
   final SizeVariant? variant;
 
   const TaskCard({
     Key? key,
     required this.task,
-    this.showEmployees = true,
-    this.showVehicles = true,
+    required this.data,
     this.variant,
   }) : super(key: key);
-
-  static const _typeIcons = {
-    GrafikTaskType.Produkcja: Icons.apartment,
-    GrafikTaskType.Budowa: Icons.home_repair_service,
-    GrafikTaskType.Serwis: Icons.handyman,
-    GrafikTaskType.Inne: Icons.task_alt,
-  };
-
-  String _fmt(DateTime dt) =>
-      '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
 
   @override
   Widget build(BuildContext context) {
@@ -43,73 +24,10 @@ class TaskCard extends StatelessWidget {
         final sizeVariant =
             variant ?? TileSizeResolver.resolve(width: constraints.maxWidth);
 
-        final state = context.watch<GrafikCubit>().state;
-        final assignedIds = state.assignments
-            .where((a) => a.taskId == task.id)
-            .map((a) => a.workerId)
-            .toSet();
-        final employees =
-            state.employees.where((e) => assignedIds.contains(e.uid));
-        final vehicles =
-            state.vehicles.where((v) => task.carIds.contains(v.id));
-
-        final typeIcon = _typeIcons[task.taskType] ?? Icons.task;
-        final statusIcon = task.status.icon;
-
-        final showEmps = showEmployees && sizeVariant != SizeVariant.small;
-        final showVehs = showVehicles && sizeVariant != SizeVariant.small;
-
-        return Card(
-          margin: const EdgeInsets.all(AppSpacing.xs),
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.sm),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Icon(typeIcon,
-                        size: AppTheme.sizeFor(context.breakpoint, 24)),
-                    const SizedBox(width: AppSpacing.sm),
-                    Expanded(
-                      child: Text(
-                        task.additionalInfo,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: AppTheme.textStyleFor(
-                          context.breakpoint,
-                          Theme.of(context)
-                              .textTheme
-                              .bodyLarge!
-                              .copyWith(fontWeight: FontWeight.bold),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: AppSpacing.sm),
-                    Icon(statusIcon,
-                        size: AppTheme.sizeFor(context.breakpoint, 24)),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  '${_fmt(task.startDateTime)} - ${_fmt(task.endDateTime)}',
-                  style: AppTheme.textStyleFor(
-                    context.breakpoint,
-                    Theme.of(context).textTheme.bodyMedium!,
-                  ),
-                ),
-                if (showEmps && employees.isNotEmpty) ...[
-                  const SizedBox(height: 4),
-                  EmployeeChipList(employees: employees),
-                ],
-                if (showVehs && vehicles.isNotEmpty) ...[
-                  const SizedBox(height: 4),
-                  VehicleList(vehicleIds: task.carIds),
-                ],
-              ],
-            ),
-          ),
+        return GrafikElementCard(
+          element: task,
+          data: data,
+          variant: sizeVariant,
         );
       },
     );


### PR DESCRIPTION
## Summary
- refactor `TaskCard` to be a simple wrapper around `GrafikElementCard`
- compute `GrafikElementData` in daily `TaskList` and render tasks with `GrafikElementCard`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724834b8308333ac4513ab318ab5f2