### PR TITLE
Remove unused imports

### DIFF
--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -21,8 +21,6 @@ import 'turbo_grid/turbo_tile_delegate.dart';
 import 'turbo_grid/turbo_tile_variant.dart';
 import 'turbo_grid/widgets/clock_view_delegate.dart';
 import 'turbo_grid/widgets/simple_text_delegate.dart';
-import 'turbo_grid/widgets/vehice_delegate.dart';
-import 'turbo_grid/widgets/employee_delegate.dart';
 import 'turbo_grid/widgets/work_time_planning_delegate.dart';
 
 class GrafikElementCard extends StatelessWidget {


### PR DESCRIPTION
## Summary
- clean up GrafikElementCard by removing unused `vehice_delegate.dart` and `employee_delegate.dart` imports

## Testing
- `git grep -n "vehice_delegate"`
- `git grep -n "employee_delegate"`

------
https://chatgpt.com/codex/tasks/task_e_687251069af08333b8808e5ea0b9634d