### PR TITLE
Fix GrafikElementCard context and chip list

### DIFF
--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -48,11 +48,16 @@ class GrafikElementCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(AppRadius.md),
       ),
       padding: const EdgeInsets.all(AppSpacing.xs),
-      child: _buildContent(label, time, description),
+      child: _buildContent(context, label, time, description),
     );
   }
 
-  Widget _buildContent(String label, String time, String description) {
+  Widget _buildContent(
+    BuildContext context,
+    String label,
+    String time,
+    String description,
+  ) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -75,8 +80,10 @@ class GrafikElementCard extends StatelessWidget {
       SizeVariant.mini => 2,
     };
     final list = data.assignedEmployees.take(limit).toList();
-    final chips = list
-        .map((e) => EmployeeChip(employee: e, showFullName: showFull))
+    final List<Widget> chips = list
+        .map<Widget>(
+          (e) => EmployeeChip(employee: e, showFullName: showFull),
+        )
         .toList();
     if (data.assignedEmployees.length > limit) {
       chips.add(Text('…', style: variant.textStyle));


### PR DESCRIPTION
## Summary
- pass BuildContext through `_buildContent`
- collect employee chips as generic widgets to allow ellipsis text

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687257a57bf8833382eb5416600e8909