### PR TITLE
Fix grafik_card_delegate imports

### DIFF
--- a/shared/grafik_card_delegate.dart
+++ b/shared/grafik_card_delegate.dart
@@ -1,8 +1,8 @@
-import 'domain/models/grafik/grafik_element.dart';
-import 'domain/models/grafik/impl/task_element.dart';
-import 'domain/models/grafik/impl/task_planning_element.dart';
-import 'domain/models/grafik/impl/delivery_planning_element.dart';
-import 'domain/models/grafik/impl/time_issue_element.dart';
+import 'package:kabast/domain/models/grafik/grafik_element.dart';
+import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
+import 'package:kabast/domain/models/grafik/impl/task_element.dart';
+import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
+import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 
 abstract class GrafikElementCardDelegate {
   String getLabel();


### PR DESCRIPTION
## Summary
- use package imports for grafik element classes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872592394708333ba9947ee6833e1d6