### PR TITLE
Fix week tile width in TurboGrid

### DIFF
--- a/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart
@@ -21,14 +21,23 @@ class DeliveryPlanningWeekTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TurboGrid(
-      tiles: [
-        TurboTile(
-          priority: 1,
-          required: true,
-          delegate: _DeliveryPlanningCardDelegate(deliveryPlanning, data),
-        ),
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return TurboGrid(
+          tiles: [
+            TurboTile(
+              priority: 1,
+              required: true,
+              delegate: _DeliveryPlanningCardDelegate(
+                deliveryPlanning,
+                data,
+                width,
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -36,8 +45,9 @@ class DeliveryPlanningWeekTile extends StatelessWidget {
 class _DeliveryPlanningCardDelegate extends TurboTileDelegate {
   final DeliveryPlanningElement deliveryPlanning;
   final GrafikElementData data;
+  final double width;
 
-  _DeliveryPlanningCardDelegate(this.deliveryPlanning, this.data);
+  _DeliveryPlanningCardDelegate(this.deliveryPlanning, this.data, this.width);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -48,12 +58,6 @@ class _DeliveryPlanningCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final width = switch (v) {
-      SizeVariant.large => 320.0,
-      SizeVariant.medium => 280.0,
-      SizeVariant.small => 240.0,
-      SizeVariant.mini => 200.0,
-    };
     final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),

--- a/feature/grafik/widget/week/tiles/task_planning_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_planning_week_tile.dart
@@ -21,14 +21,19 @@ class TaskPlanningWeekTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TurboGrid(
-      tiles: [
-        TurboTile(
-          priority: 1,
-          required: true,
-          delegate: _TaskPlanningCardDelegate(taskPlanning, data),
-        ),
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return TurboGrid(
+          tiles: [
+            TurboTile(
+              priority: 1,
+              required: true,
+              delegate: _TaskPlanningCardDelegate(taskPlanning, data, width),
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -36,8 +41,9 @@ class TaskPlanningWeekTile extends StatelessWidget {
 class _TaskPlanningCardDelegate extends TurboTileDelegate {
   final TaskPlanningElement taskPlanning;
   final GrafikElementData data;
+  final double width;
 
-  _TaskPlanningCardDelegate(this.taskPlanning, this.data);
+  _TaskPlanningCardDelegate(this.taskPlanning, this.data, this.width);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -48,12 +54,6 @@ class _TaskPlanningCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final width = switch (v) {
-      SizeVariant.large => 320.0,
-      SizeVariant.medium => 280.0,
-      SizeVariant.small => 240.0,
-      SizeVariant.mini => 200.0,
-    };
     final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -20,14 +20,19 @@ class TaskWeekTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TurboGrid(
-      tiles: [
-        TurboTile(
-          priority: 1,
-          required: true,
-          delegate: _TaskCardDelegate(task, data),
-        ),
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return TurboGrid(
+          tiles: [
+            TurboTile(
+              priority: 1,
+              required: true,
+              delegate: _TaskCardDelegate(task, data, width),
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -35,8 +40,9 @@ class TaskWeekTile extends StatelessWidget {
 class _TaskCardDelegate extends TurboTileDelegate {
   final TaskElement task;
   final GrafikElementData data;
+  final double width;
 
-  _TaskCardDelegate(this.task, this.data);
+  _TaskCardDelegate(this.task, this.data, this.width);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -47,12 +53,6 @@ class _TaskCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final width = switch (v) {
-      SizeVariant.large => 320.0,
-      SizeVariant.medium => 280.0,
-      SizeVariant.small => 240.0,
-      SizeVariant.mini => 200.0,
-    };
     final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),

--- a/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
@@ -21,14 +21,19 @@ class TimeIssueWeekTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TurboGrid(
-      tiles: [
-        TurboTile(
-          priority: 1,
-          required: true,
-          delegate: _TimeIssueCardDelegate(timeIssue, data),
-        ),
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return TurboGrid(
+          tiles: [
+            TurboTile(
+              priority: 1,
+              required: true,
+              delegate: _TimeIssueCardDelegate(timeIssue, data, width),
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -36,8 +41,9 @@ class TimeIssueWeekTile extends StatelessWidget {
 class _TimeIssueCardDelegate extends TurboTileDelegate {
   final TimeIssueElement timeIssue;
   final GrafikElementData data;
+  final double width;
 
-  _TimeIssueCardDelegate(this.timeIssue, this.data);
+  _TimeIssueCardDelegate(this.timeIssue, this.data, this.width);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -48,12 +54,6 @@ class _TimeIssueCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final width = switch (v) {
-      SizeVariant.large => 320.0,
-      SizeVariant.medium => 280.0,
-      SizeVariant.small => 240.0,
-      SizeVariant.mini => 200.0,
-    };
     final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),


### PR DESCRIPTION
## Summary
- stretch GrafikElementCard tiles to full column width in weekly view

## Testing
- `apt-get update`
- *Unable to run `flutter analyze` due to missing `flutter`*

------
https://chatgpt.com/codex/tasks/task_e_68725e34e35c8333ba3efeccf5c431d2