### PR TITLE
Add SizeVariant support to EmployeeChip

### DIFF
--- a/shared/employee_chip.dart
+++ b/shared/employee_chip.dart
@@ -2,18 +2,39 @@ import 'package:flutter/material.dart';
 import 'package:kabast/domain/models/employee.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/size_variants.dart';
 import 'package:kabast/theme/theme.dart';
 
 class EmployeeChip extends StatelessWidget {
   final Employee employee;
   final bool? showFullName;
+  final SizeVariant sizeVariant;
 
-  const EmployeeChip({super.key, required this.employee, this.showFullName});
+  const EmployeeChip({
+    super.key,
+    required this.employee,
+    this.showFullName,
+    this.sizeVariant = SizeVariant.small,
+  });
 
   @override
   Widget build(BuildContext context) {
     final bp = context.breakpoint;
     final bool full = showFullName ?? bp != Breakpoint.small;
+    double scale() {
+      switch (sizeVariant) {
+        case SizeVariant.large:
+          return 1.5;
+        case SizeVariant.medium:
+          return 1.2;
+        case SizeVariant.small:
+          return 1.0;
+        case SizeVariant.mini:
+          return 0.8;
+      }
+    }
+
+    final paddingScale = scale();
 
     if (full) {
       final name = employee.formattedNameWithSecondInitial;
@@ -28,22 +49,16 @@ class EmployeeChip extends StatelessWidget {
               children: [
                 TextSpan(
                   text: surname.substring(0, 1),
-                  style: AppTheme.textStyleFor(
-                    bp,
-                    Theme.of(context).textTheme.bodyLarge!.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: Colors.black,
-                        ),
+                  style: sizeVariant.textStyle.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
                   ),
                 ),
                 TextSpan(
                   text: surname.substring(1) + rest,
-                  style: AppTheme.textStyleFor(
-                    bp,
-                    Theme.of(context).textTheme.bodyLarge!.copyWith(
-                          fontWeight: FontWeight.normal,
-                          color: Colors.black,
-                        ),
+                  style: sizeVariant.textStyle.copyWith(
+                    fontWeight: FontWeight.normal,
+                    color: Colors.black,
                   ),
                 ),
               ],
@@ -51,8 +66,8 @@ class EmployeeChip extends StatelessWidget {
           ),
         ),
         padding: EdgeInsets.symmetric(
-          horizontal: AppTheme.sizeFor(bp, 2),
-          vertical: AppTheme.sizeFor(bp, 1),
+          horizontal: AppTheme.sizeFor(bp, 2 * paddingScale),
+          vertical: AppTheme.sizeFor(bp, 1 * paddingScale),
         ),
         labelPadding: EdgeInsets.zero,
         visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
@@ -70,18 +85,15 @@ class EmployeeChip extends StatelessWidget {
           .take(2)
           .join();
       return Chip(
-        padding: EdgeInsets.all(AppTheme.sizeFor(bp, 1)),
+        padding: EdgeInsets.all(AppTheme.sizeFor(bp, 1 * paddingScale)),
         labelPadding: EdgeInsets.zero,
         visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         label: Text(
           initials,
-          style: AppTheme.textStyleFor(
-            bp,
-            Theme.of(context).textTheme.bodySmall!.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: Colors.black,
-                ),
+          style: sizeVariant.textStyle.copyWith(
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
           ),
         ),
         backgroundColor: Colors.grey.shade200,

--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -53,7 +53,7 @@ class GrafikElementCard extends StatelessWidget {
         final children = <Widget>[
           Text(label, style: variant.textStyle, overflow: TextOverflow.ellipsis),
           if (data.assignedEmployees.isNotEmpty)
-            _employeeRow(context, canShowFullNames),
+            _employeeRow(context, canShowFullNames, variant),
           if (showTime)
             Text(time,
                 style: variant.textStyle,
@@ -90,10 +90,18 @@ class GrafikElementCard extends StatelessWidget {
     );
   }
 
-  Widget _employeeRow(BuildContext context, bool showFullName) {
+  Widget _employeeRow(
+    BuildContext context,
+    bool showFullName,
+    SizeVariant sizeVariant,
+  ) {
     final chips = data.assignedEmployees
         .map<Widget>(
-          (e) => EmployeeChip(employee: e, showFullName: showFullName),
+          (e) => EmployeeChip(
+            employee: e,
+            showFullName: showFullName,
+            sizeVariant: sizeVariant,
+          ),
         )
         .toList();
     return Wrap(
@@ -128,6 +136,7 @@ class _EmployeeChipRowDelegate extends TurboTileDelegate {
                 .map((e) => EmployeeChip(
                       employee: e,
                       showFullName: context.breakpoint != Breakpoint.small,
+                      sizeVariant: v,
                     ))
                 .toList(),
           ),


### PR DESCRIPTION
## Summary
- extend `EmployeeChip` with `sizeVariant` parameter
- apply the chosen `SizeVariant` for text style and padding
- propagate current `SizeVariant` through `GrafikElementCard`

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68725f6826c48333b3f6b6729f4c1890