### PR TITLE
Update EmployeeChip sizing

### DIFF
--- a/shared/employee_chip.dart
+++ b/shared/employee_chip.dart
@@ -4,6 +4,7 @@ import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/size_variants.dart';
 import 'package:kabast/theme/theme.dart';
+import 'employee_chip_style_resolver.dart';
 
 class EmployeeChip extends StatelessWidget {
   final Employee employee;
@@ -21,20 +22,15 @@ class EmployeeChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final bp = context.breakpoint;
     final bool full = showFullName ?? bp != Breakpoint.small;
-    double scale() {
-      switch (sizeVariant) {
-        case SizeVariant.large:
-          return 1.5;
-        case SizeVariant.medium:
-          return 1.2;
-        case SizeVariant.small:
-          return 1.0;
-        case SizeVariant.mini:
-          return 0.8;
-      }
-    }
-
-    final paddingScale = scale();
+    final style = const EmployeeChipStyleResolver().styleFor(sizeVariant);
+    final padding = EdgeInsets.symmetric(
+      horizontal: AppTheme.sizeFor(bp, style.horizontal),
+      vertical: AppTheme.sizeFor(bp, style.vertical),
+    );
+    final textStyle = TextStyle(
+      fontSize: AppTheme.sizeFor(bp, style.fontSize),
+      height: 1,
+    );
 
     if (full) {
       final name = employee.formattedNameWithSecondInitial;
@@ -49,14 +45,14 @@ class EmployeeChip extends StatelessWidget {
               children: [
                 TextSpan(
                   text: surname.substring(0, 1),
-                  style: sizeVariant.textStyle.copyWith(
+                  style: textStyle.copyWith(
                     fontWeight: FontWeight.bold,
                     color: Colors.black,
                   ),
                 ),
                 TextSpan(
                   text: surname.substring(1) + rest,
-                  style: sizeVariant.textStyle.copyWith(
+                  style: textStyle.copyWith(
                     fontWeight: FontWeight.normal,
                     color: Colors.black,
                   ),
@@ -65,16 +61,13 @@ class EmployeeChip extends StatelessWidget {
             ),
           ),
         ),
-        padding: EdgeInsets.symmetric(
-          horizontal: AppTheme.sizeFor(bp, 2 * paddingScale),
-          vertical: AppTheme.sizeFor(bp, 1 * paddingScale),
-        ),
+        padding: padding,
         labelPadding: EdgeInsets.zero,
         visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         backgroundColor: Colors.grey.shade200,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(4),
+          borderRadius: BorderRadius.circular(style.borderRadius),
         ),
       );
     } else {
@@ -85,20 +78,20 @@ class EmployeeChip extends StatelessWidget {
           .take(2)
           .join();
       return Chip(
-        padding: EdgeInsets.all(AppTheme.sizeFor(bp, 1 * paddingScale)),
+        padding: EdgeInsets.all(AppTheme.sizeFor(bp, style.vertical)),
         labelPadding: EdgeInsets.zero,
         visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         label: Text(
           initials,
-          style: sizeVariant.textStyle.copyWith(
+          style: textStyle.copyWith(
             fontWeight: FontWeight.bold,
             color: Colors.black,
           ),
         ),
         backgroundColor: Colors.grey.shade200,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderRadius: BorderRadius.circular(style.borderRadius),
         ),
       );
     }

--- a/shared/employee_chip_style_resolver.dart
+++ b/shared/employee_chip_style_resolver.dart
@@ -1,0 +1,53 @@
+import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/size_variants.dart';
+
+class EmployeeChipStyle {
+  final double horizontal;
+  final double vertical;
+  final double fontSize;
+  final double borderRadius;
+
+  const EmployeeChipStyle({
+    required this.horizontal,
+    required this.vertical,
+    required this.fontSize,
+    required this.borderRadius,
+  });
+}
+
+class EmployeeChipStyleResolver {
+  const EmployeeChipStyleResolver();
+
+  EmployeeChipStyle styleFor(SizeVariant variant) {
+    switch (variant) {
+      case SizeVariant.large:
+        return const EmployeeChipStyle(
+          horizontal: 6,
+          vertical: 3,
+          fontSize: 16,
+          borderRadius: AppRadius.lg,
+        );
+      case SizeVariant.medium:
+        return const EmployeeChipStyle(
+          horizontal: 5,
+          vertical: 2,
+          fontSize: 14,
+          borderRadius: AppRadius.md,
+        );
+      case SizeVariant.small:
+        return const EmployeeChipStyle(
+          horizontal: 3,
+          vertical: 1,
+          fontSize: 12,
+          borderRadius: AppRadius.sm,
+        );
+      case SizeVariant.mini:
+        return const EmployeeChipStyle(
+          horizontal: 2,
+          vertical: 0.5,
+          fontSize: 10,
+          borderRadius: AppRadius.sm,
+        );
+    }
+  }
+}

--- a/shared/index.dart
+++ b/shared/index.dart
@@ -1,6 +1,7 @@
 export 'custom_fab.dart';
 export 'small_chip.dart';
 export 'employee_chip.dart';
+export 'employee_chip_style_resolver.dart';
 export 'form/standard/standard_form_field.dart';
 export 'form/standard/standard_form_section.dart';
 export 'utils/date_formatting.dart';


### PR DESCRIPTION
## Summary
- add EmployeeChipStyleResolver for flexible sizing
- scale padding and text style in EmployeeChip
- re-export style resolver in shared index

## Testing
- `dart format -o none --set-exit-if-changed shared/employee_chip.dart shared/employee_chip_style_resolver.dart shared/index.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872618f037c8333a3d02e3179dc142b