### PR TITLE
Ensure GrafikElementCard fills TurboGrid space

### DIFF
--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -75,16 +75,21 @@ class GrafikElementCard extends StatelessWidget {
           );
         }
 
-        return Container(
-          height: constraints.maxHeight,
-          decoration: BoxDecoration(
-            color: style.backgroundColor,
-            borderRadius: BorderRadius.circular(AppRadius.md),
-          ),
-          padding: const EdgeInsets.all(AppSpacing.xs),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
+        return SizedBox.expand(
+          child: Container(
+            decoration: BoxDecoration(
+              color: style.backgroundColor,
+              borderRadius: BorderRadius.circular(AppRadius.md),
+            ),
+            padding: const EdgeInsets.all(AppSpacing.xs),
+            child: Column(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ...children,
+                const Spacer(),
+              ],
+            ),
           ),
         );
       },


### PR DESCRIPTION
## Summary
- update `GrafikElementCard` so that the card expands to fill the tile
- keep the column at `MainAxisSize.max` and use a spacer so the content stretches vertically

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*
- `apt-get install -y flutter` *(fails: `Unable to locate package flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68727cd890408333818f8e7ae395a25b