### PR TITLE
Refactor TurboTile variants with constraints

### DIFF
--- a/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart
@@ -24,6 +24,7 @@ class DeliveryPlanningWeekTile extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
         return TurboGrid(
           tiles: [
             TurboTile(
@@ -33,6 +34,7 @@ class DeliveryPlanningWeekTile extends StatelessWidget {
                 deliveryPlanning,
                 data,
                 width,
+                height,
               ),
             ),
           ],
@@ -46,8 +48,9 @@ class _DeliveryPlanningCardDelegate extends TurboTileDelegate {
   final DeliveryPlanningElement deliveryPlanning;
   final GrafikElementData data;
   final double width;
+  final double height;
 
-  _DeliveryPlanningCardDelegate(this.deliveryPlanning, this.data, this.width);
+  _DeliveryPlanningCardDelegate(this.deliveryPlanning, this.data, this.width, this.height);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -58,12 +61,9 @@ class _DeliveryPlanningCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),
-      builder: (context) => SizedBox(
-        width: width,
-        height: height,
+      builder: (context, constraints) => SizedBox.expand(
         child: GrafikElementCard(
           element: deliveryPlanning,
           data: data,

--- a/feature/grafik/widget/week/tiles/task_planning_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_planning_week_tile.dart
@@ -24,12 +24,13 @@ class TaskPlanningWeekTile extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
         return TurboGrid(
           tiles: [
             TurboTile(
               priority: 1,
               required: true,
-              delegate: _TaskPlanningCardDelegate(taskPlanning, data, width),
+              delegate: _TaskPlanningCardDelegate(taskPlanning, data, width, height),
             ),
           ],
         );
@@ -42,8 +43,9 @@ class _TaskPlanningCardDelegate extends TurboTileDelegate {
   final TaskPlanningElement taskPlanning;
   final GrafikElementData data;
   final double width;
+  final double height;
 
-  _TaskPlanningCardDelegate(this.taskPlanning, this.data, this.width);
+  _TaskPlanningCardDelegate(this.taskPlanning, this.data, this.width, this.height);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -54,12 +56,9 @@ class _TaskPlanningCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),
-      builder: (context) => SizedBox(
-        width: width,
-        height: height,
+      builder: (context, constraints) => SizedBox.expand(
         child: GrafikElementCard(
           element: taskPlanning,
           data: data,

--- a/feature/grafik/widget/week/tiles/task_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/task_week_tile.dart
@@ -23,12 +23,13 @@ class TaskWeekTile extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
         return TurboGrid(
           tiles: [
             TurboTile(
               priority: 1,
               required: true,
-              delegate: _TaskCardDelegate(task, data, width),
+              delegate: _TaskCardDelegate(task, data, width, height),
             ),
           ],
         );
@@ -41,8 +42,9 @@ class _TaskCardDelegate extends TurboTileDelegate {
   final TaskElement task;
   final GrafikElementData data;
   final double width;
+  final double height;
 
-  _TaskCardDelegate(this.task, this.data, this.width);
+  _TaskCardDelegate(this.task, this.data, this.width, this.height);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -53,12 +55,9 @@ class _TaskCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),
-      builder: (context) => SizedBox(
-        width: width,
-        height: height,
+      builder: (context, constraints) => SizedBox.expand(
         child: GrafikElementCard(
           element: task,
           data: data,

--- a/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/time_issue_week_tile.dart
@@ -24,12 +24,13 @@ class TimeIssueWeekTile extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
         return TurboGrid(
           tiles: [
             TurboTile(
               priority: 1,
               required: true,
-              delegate: _TimeIssueCardDelegate(timeIssue, data, width),
+              delegate: _TimeIssueCardDelegate(timeIssue, data, width, height),
             ),
           ],
         );
@@ -42,8 +43,9 @@ class _TimeIssueCardDelegate extends TurboTileDelegate {
   final TimeIssueElement timeIssue;
   final GrafikElementData data;
   final double width;
+  final double height;
 
-  _TimeIssueCardDelegate(this.timeIssue, this.data, this.width);
+  _TimeIssueCardDelegate(this.timeIssue, this.data, this.width, this.height);
 
   @override
   List<TurboTileVariant> createVariants() => [
@@ -54,12 +56,9 @@ class _TimeIssueCardDelegate extends TurboTileDelegate {
       ];
 
   TurboTileVariant _variant(SizeVariant v) {
-    final height = v.height * 3;
     return TurboTileVariant(
       size: Size(width, height),
-      builder: (context) => SizedBox(
-        width: width,
-        height: height,
+      builder: (context, constraints) => SizedBox.expand(
         child: GrafikElementCard(
           element: timeIssue,
           data: data,

--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -133,8 +133,7 @@ class _EmployeeChipRowDelegate extends TurboTileDelegate {
 
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
         size: Size(width, v.height),
-        builder: (context) => SizedBox(
-          height: v.height,
+        builder: (context, constraints) => SizedBox.expand(
           child: Wrap(
             spacing: AppTheme.sizeFor(context.breakpoint, 4),
             runSpacing: AppTheme.sizeFor(context.breakpoint, 4),
@@ -165,8 +164,7 @@ class _VehicleChipRowDelegate extends TurboTileDelegate {
 
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
         size: Size(width, v.height),
-        builder: (context) => SizedBox(
-          height: v.height,
+        builder: (context, constraints) => SizedBox.expand(
           child: Wrap(
             spacing: AppTheme.sizeFor(context.breakpoint, 4),
             runSpacing: AppTheme.sizeFor(context.breakpoint, 4),

--- a/shared/turbo_grid/turbo_grid.dart
+++ b/shared/turbo_grid/turbo_grid.dart
@@ -126,7 +126,13 @@ class TurboGrid extends StatelessWidget {
         Positioned(
           left: x,
           top: y,
-          child: SizedBox(width: w, height: h, child: v.builder(ctx)),
+          child: SizedBox(
+            width: w,
+            height: h,
+            child: LayoutBuilder(
+              builder: (c, constraints) => v.builder(c, constraints),
+            ),
+          ),
         ),
       );
 

--- a/shared/turbo_grid/turbo_tile_variant.dart
+++ b/shared/turbo_grid/turbo_tile_variant.dart
@@ -8,7 +8,11 @@ class TurboTileVariant {
   final Size size;
 
   /// Budowniczy, który generuje zawartość kafelka dla tego wariantu.
-  final WidgetBuilder builder;
+  ///
+  /// Zamiast przyjmować jedynie [BuildContext], przekazujemy również
+  /// [BoxConstraints] tak, aby implementacje mogły wykorzystać
+  /// dostępne ograniczenia przy budowaniu widżetu.
+  final Widget Function(BuildContext, BoxConstraints) builder;
 
   TurboTileVariant({required this.size, required this.builder});
 }

--- a/shared/turbo_grid/widgets/clock_view_delegate.dart
+++ b/shared/turbo_grid/widgets/clock_view_delegate.dart
@@ -21,32 +21,31 @@ class ClockViewDelegate extends TurboTileDelegate {
   // ---------------------------------------------------------------------------
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
     size: Size(width, v.height),
-    builder: (c) {
+    builder: (c, constraints) {
       final same = _sameDay();
       final fmt = same ? DateFormat.Hm() : DateFormat('dd.MM');
 
       final from = Text(fmt.format(start), style: v.textStyle);
       final to   = Text(fmt.format(end),   style: v.textStyle);
 
-      return SizedBox(
-        height: v.height,
+      return SizedBox.expand(
         child: same
             ? Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            from,
-            const SizedBox(width: 1),
-            Icon(Icons.arrow_right_alt, size: v.iconSize),
-            const SizedBox(width: 1),
-            to,
-          ],
-        )
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                from,
+                const SizedBox(width: 1),
+                Icon(Icons.arrow_right_alt, size: v.iconSize),
+                const SizedBox(width: 1),
+                to,
+              ],
+            )
             : Text(
-          "${fmt.format(start)} - ${fmt.format(end)}",
-          style: v.textStyle,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
+              "${fmt.format(start)} - ${fmt.format(end)}",
+              style: v.textStyle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
       );
     },
   );

--- a/shared/turbo_grid/widgets/employee_delegate.dart
+++ b/shared/turbo_grid/widgets/employee_delegate.dart
@@ -23,8 +23,7 @@ class EmployeeDelegate extends TurboTileDelegate {
 
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
     size: Size(width, v.height),
-    builder: (context) => SizedBox(
-      height: v.height,
+    builder: (context, constraints) => SizedBox.expand(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/shared/turbo_grid/widgets/simple_text_delegate.dart
+++ b/shared/turbo_grid/widgets/simple_text_delegate.dart
@@ -23,8 +23,7 @@ class SimpleTextDelegate extends TurboTileDelegate {
 
     return TurboTileVariant(
       size: size,
-      builder: (context) => SizedBox(
-        height: v.height,
+      builder: (context, constraints) => SizedBox.expand(
         child: Text(
           text,
           style: v.textStyle,

--- a/shared/turbo_grid/widgets/vehicle_delegate.dart
+++ b/shared/turbo_grid/widgets/vehicle_delegate.dart
@@ -19,8 +19,7 @@ class VehicleDelegate extends TurboTileDelegate {
 
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
     size: Size(width, v.height),
-    builder: (c) => SizedBox(
-      height: v.height,
+    builder: (c, constraints) => SizedBox.expand(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/shared/turbo_grid/widgets/work_time_planning_delegate.dart
+++ b/shared/turbo_grid/widgets/work_time_planning_delegate.dart
@@ -23,8 +23,7 @@ class WorkTimePlanningDelegate extends TurboTileDelegate {
 
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
     size: Size(width, v.height),
-    builder: (c) => SizedBox(
-      height: v.height,
+    builder: (c, constraints) => SizedBox.expand(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/shared/turbo_grid/widgets/worker_count_delegate.dart
+++ b/shared/turbo_grid/widgets/worker_count_delegate.dart
@@ -18,8 +18,7 @@ class WorkerCountDelegate extends TurboTileDelegate {
 
   TurboTileVariant _variant(SizeVariant v, double width) => TurboTileVariant(
     size: Size(width, v.height),
-    builder: (context) => SizedBox(
-      height: v.height,
+    builder: (context, constraints) => SizedBox.expand(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [


### PR DESCRIPTION
## Summary
- allow `TurboTileVariant` builders to receive `BoxConstraints`
- pipe constraints through `TurboGrid` `_buildPositioned`
- update TurboTile delegates to use the new builder signature
- size week tile delegates using incoming constraints

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687288477b90833392ea7e1cfac57827