### PR TITLE
Update GrafikElementCard UI

### DIFF
--- a/feature/grafik/constants/element_styles.dart
+++ b/feature/grafik/constants/element_styles.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 
 class GrafikElementStyle {
   final Color backgroundColor;
+  final Color borderColor;
   final IconData? badgeIcon;
   final Color? badgeColor;
 
   const GrafikElementStyle({
     required this.backgroundColor,
+    required this.borderColor,
     this.badgeIcon,
     this.badgeColor,
   });
@@ -20,24 +22,29 @@ class GrafikElementStyleResolver {
       case 'TaskElement':
         return GrafikElementStyle(
           backgroundColor: Colors.lightBlue.shade100,
+          borderColor: Colors.lightBlue,
         );
       case 'TaskPlanningElement':
         return GrafikElementStyle(
           backgroundColor: Colors.green.shade100,
+          borderColor: Colors.green,
           badgeIcon: Icons.priority_high,
           badgeColor: Colors.red.shade700,
         );
       case 'DeliveryPlanningElement':
         return GrafikElementStyle(
           backgroundColor: Colors.orange.shade100,
+          borderColor: Colors.orange,
         );
       case 'TimeIssueElement':
         return GrafikElementStyle(
           backgroundColor: Colors.red.shade100,
+          borderColor: Colors.red,
         );
       default:
         return GrafikElementStyle(
           backgroundColor: Colors.grey.shade200,
+          borderColor: Colors.grey,
         );
     }
   }

--- a/feature/grafik/constants/enums_ui.dart
+++ b/feature/grafik/constants/enums_ui.dart
@@ -15,3 +15,18 @@ extension GrafikStatusX on GrafikStatus {
     }
   }
 }
+
+extension GrafikTaskTypeX on GrafikTaskType {
+  IconData get icon {
+    switch (this) {
+      case GrafikTaskType.Budowa:
+        return Icons.construction;
+      case GrafikTaskType.Produkcja:
+        return Icons.precision_manufacturing;
+      case GrafikTaskType.Serwis:
+        return Icons.handyman;
+      case GrafikTaskType.Inne:
+        return Icons.more_horiz;
+    }
+  }
+}

--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -6,6 +6,9 @@ import '../domain/models/grafik/grafik_element_data.dart';
 import '../domain/models/employee.dart';
 import '../domain/models/vehicle.dart';
 import '../feature/grafik/constants/element_styles.dart';
+import '../feature/grafik/constants/enums_ui.dart';
+import '../domain/models/grafik/impl/task_element.dart';
+import '../domain/models/grafik/impl/task_planning_element.dart';
 import '../theme/app_tokens.dart';
 import '../theme/size_variants.dart';
 import '../theme/theme.dart';
@@ -35,6 +38,15 @@ class GrafikElementCard extends StatelessWidget {
     final time = delegate.getTimeInfo();
     final description = delegate.getDescription();
 
+    IconData? typeIcon;
+    IconData? statusIcon;
+    if (element is TaskElement) {
+      typeIcon = (element as TaskElement).taskType.icon;
+      statusIcon = (element as TaskElement).status.icon;
+    } else if (element is TaskPlanningElement) {
+      typeIcon = (element as TaskPlanningElement).taskType.icon;
+    }
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final w = constraints.maxWidth;
@@ -47,8 +59,21 @@ class GrafikElementCard extends StatelessWidget {
 
         final children = <Widget>[];
 
-        // Order number / label
-        children.add(Text(label, style: ts, overflow: TextOverflow.ellipsis));
+        // Description first line
+        children.add(Text(
+          description,
+          style: ts,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ));
+        remaining -= lineH;
+
+        // Order number / label in bold
+        children.add(Text(
+          label,
+          style: ts.copyWith(fontWeight: FontWeight.bold),
+          overflow: TextOverflow.ellipsis,
+        ));
         remaining -= lineH;
 
         // Employees row - always visible, clipped to two lines
@@ -81,32 +106,55 @@ class GrafikElementCard extends StatelessWidget {
           remaining -= lineH;
         }
 
-        // Description grows with available space
-        final descLines = (remaining / lineH).floor();
-        if (descLines > 0) {
-          children.add(
-            Text(
-              description,
-              style: ts,
-              maxLines: descLines,
-              overflow: TextOverflow.ellipsis,
-            ),
-          );
-        }
+
 
         return SizedBox.expand(
           child: Container(
             decoration: BoxDecoration(
-              color: style.backgroundColor,
+              color: Colors.white,
               borderRadius: BorderRadius.circular(AppRadius.md),
+              border: Border.all(
+                color: style.borderColor,
+                width: AppSpacing.borderThin,
+              ),
             ),
             padding: const EdgeInsets.all(AppSpacing.xs),
-            child: Column(
-              mainAxisSize: MainAxisSize.max,
-              crossAxisAlignment: CrossAxisAlignment.start,
+            child: Stack(
               children: [
-                ...children,
-                const Spacer(),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (typeIcon != null)
+                      Padding(
+                        padding: const EdgeInsets.only(right: AppSpacing.xs),
+                        child: Icon(
+                          typeIcon,
+                          size: variant.iconSize,
+                          color: style.borderColor,
+                        ),
+                      ),
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ...children,
+                          const Spacer(),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                if (statusIcon != null)
+                  Positioned(
+                    right: 0,
+                    bottom: 0,
+                    child: Icon(
+                      statusIcon,
+                      size: variant.iconSize,
+                      color: style.borderColor,
+                    ),
+                  ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- outline border color in `element_styles`
- add UI icons for `GrafikTaskType`
- make `GrafikElementCard` white with colored border
- show description before order number and add task/status icons

## Testing
- `apt-get update`
- ❌ `dart format -o none -l 120 feature/grafik/constants/element_styles.dart shared/grafik_element_card.dart feature/grafik/constants/enums_ui.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c21b84608333942735c65c09639d