### PR TITLE
Fix small fonts on tablets

### DIFF
--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'dart:math' as math;
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/theme.dart';
@@ -31,10 +32,11 @@ class _SingleDayGrafikViewState extends State<SingleDayGrafikView> {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final width = constraints.maxWidth == double.infinity
-            ? MediaQuery.of(context).size.width
-            : constraints.maxWidth;
-        final bp = breakpointFromWidth(width);
+        final size = MediaQuery.of(context).size;
+        final shortSide = constraints.maxWidth == double.infinity
+            ? size.shortestSide
+            : math.min(constraints.maxWidth, constraints.maxHeight);
+        final bp = breakpointFromWidth(shortSide);
 
         final colorScheme = Theme.of(context).colorScheme;
         return ResponsiveScaffold(

--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -100,7 +100,9 @@ class GrafikElementCard extends StatelessWidget {
               color: style.backgroundColor,
               borderRadius: BorderRadius.circular(AppRadius.md),
             ),
-            padding: const EdgeInsets.all(AppSpacing.xs),
+            padding: EdgeInsets.all(
+              AppSpacing.scaled(AppSpacing.xs, context.breakpoint),
+            ),
             child: Column(
               mainAxisSize: MainAxisSize.max,
               crossAxisAlignment: CrossAxisAlignment.start,

--- a/shared/responsive/responsive_layout.dart
+++ b/shared/responsive/responsive_layout.dart
@@ -1,10 +1,11 @@
 import "package:flutter/material.dart";
+import 'dart:math' as math;
 enum Breakpoint { small, medium, large }
 
-/// Returns the [Breakpoint] for a given screen width.
-Breakpoint breakpointFromWidth(double width) {
-  if (width < 600) return Breakpoint.small;
-  if (width < 1000) return Breakpoint.medium;
+/// Returns the [Breakpoint] for the given shortest side length.
+Breakpoint breakpointFromWidth(double shortSide) {
+  if (shortSide < 600) return Breakpoint.small;
+  if (shortSide < 1000) return Breakpoint.medium;
   return Breakpoint.large;
 }
 
@@ -49,10 +50,11 @@ class ResponsiveScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final width = constraints.maxWidth == double.infinity
-            ? MediaQuery.of(context).size.width
-            : constraints.maxWidth;
-        final bp = _fromWidth(width);
+        final size = MediaQuery.of(context).size;
+        final shortSide = constraints.maxWidth == double.infinity
+            ? size.shortestSide
+            : math.min(constraints.maxWidth, constraints.maxHeight);
+        final bp = _fromWidth(shortSide);
         return BreakpointProvider(
           breakpoint: bp,
           child: Scaffold(

--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -1,6 +1,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'dart:math' as math;
 
 /// Stałe odstępów, marginesów, paddingów
 class AppSpacing {
@@ -10,13 +11,18 @@ class AppSpacing {
   static const double lg = 8.0;
 
   static double _scale(Breakpoint bp) {
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final shortSide =
+        math.min(view.physicalSize.width, view.physicalSize.height) /
+            view.devicePixelRatio;
+    final factor = shortSide >= 600 ? 2.0 : 1.0;
     switch (bp) {
       case Breakpoint.small:
-        return 1.0;
+        return 1.0 * factor;
       case Breakpoint.medium:
-        return 1.5;
+        return 1.5 * factor;
       case Breakpoint.large:
-        return 2.0;
+        return 2.0 * factor;
     }
   }
 

--- a/theme/size_variants.dart
+++ b/theme/size_variants.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:math' as math;
 
 /// Rozmiary kafelków (widok tygodniowy i inne gridy).
 enum SizeVariant { large, medium, small, mini }
@@ -7,7 +8,11 @@ extension SizeVariantSpec on SizeVariant {
   double get _scale {
     final view = WidgetsBinding.instance.platformDispatcher.views.first;
     final width = view.physicalSize.width / view.devicePixelRatio;
-    return (width / 400).clamp(0.8, 1.2);
+    final shortSide =
+        math.min(view.physicalSize.width, view.physicalSize.height) /
+            view.devicePixelRatio;
+    final base = (width / 400).clamp(0.8, 1.2);
+    return shortSide >= 600 ? 2.0 : base;
   }
 
   /// Wysokość kafelka ‑ **musi być taka sama** we wszystkich delegatach.

--- a/theme/theme.dart
+++ b/theme/theme.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
+import 'dart:math' as math;
 import 'app_tokens.dart';
 import 'color_schemes.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class AppTheme {
+  static bool _largeScreen() {
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final shortest =
+        math.min(view.physicalSize.width, view.physicalSize.height) /
+            view.devicePixelRatio;
+    return shortest >= 600;
+  }
+
   static double _scaleFor(Breakpoint bp) {
     switch (bp) {
       case Breakpoint.small:
@@ -16,7 +25,7 @@ class AppTheme {
   }
 
   static TextStyle textStyleFor(Breakpoint bp, TextStyle style) {
-    final scale = _scaleFor(bp);
+    final scale = _largeScreen() ? 2.0 : _scaleFor(bp);
     return style.copyWith(
       fontSize: style.fontSize != null ? style.fontSize! * scale : null,
     );
@@ -24,12 +33,17 @@ class AppTheme {
 
   /// Scales arbitrary size values according to the current [Breakpoint].
   static double sizeFor(Breakpoint bp, double size) {
-    return size * _scaleFor(bp);
+    final scale = _largeScreen() ? 2.0 : _scaleFor(bp);
+    return size * scale;
   }
   static ThemeData buildTheme() {
     final view = WidgetsBinding.instance.platformDispatcher.views.first;
     final width = view.physicalSize.width / view.devicePixelRatio;
-    final scale = (width / 400).clamp(0.8, 1.2);
+    final shortSide =
+        math.min(view.physicalSize.width, view.physicalSize.height) /
+            view.devicePixelRatio;
+    final base = (width / 400).clamp(0.8, 1.2);
+    final scale = shortSide >= 600 ? 2.0 : base;
 
     final scheme = lightColorScheme;
     return ThemeData(


### PR DESCRIPTION
## Summary
- compute breakpoint from the shortest screen side
- upscale all tile-related sizes when the shortest side is large
- apply responsive padding in GrafikElementCard

## Testing
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c2466b1c833398f57254ad89ff35