### PR TITLE
Move plan fields to TaskPlanningElement

### DIFF
--- a/data/dto/grafik/task_planning_element_dto.dart
+++ b/data/dto/grafik/task_planning_element_dto.dart
@@ -12,6 +12,7 @@ class TaskPlanningElementDto extends GrafikElementDto {
   final int minutes;
   final bool highPriority;
   final bool isPending;
+  final List<String> plannedWorkerIds;
 
   TaskPlanningElementDto({
     required super.id,
@@ -29,6 +30,7 @@ class TaskPlanningElementDto extends GrafikElementDto {
     required this.minutes,
     required this.highPriority,
     this.isPending = false,
+    this.plannedWorkerIds = const [],
   });
 
   factory TaskPlanningElementDto.fromJson(Map<String, dynamic> json) {
@@ -64,6 +66,8 @@ class TaskPlanningElementDto extends GrafikElementDto {
       minutes: json['minutes'] as int? ?? 60,
       highPriority: json['highPriority'] as bool? ?? false,
       isPending: json['isPending'] as bool? ?? false,
+      plannedWorkerIds:
+          (json['plannedWorkerIds'] as List?)?.cast<String>() ?? const [],
     );
   }
 
@@ -76,6 +80,7 @@ class TaskPlanningElementDto extends GrafikElementDto {
         'minutes': minutes,
         'highPriority': highPriority,
         'isPending': isPending,
+        'plannedWorkerIds': plannedWorkerIds,
       };
 
   TaskPlanningElement toDomain() => TaskPlanningElement(
@@ -93,6 +98,7 @@ class TaskPlanningElementDto extends GrafikElementDto {
         addedTimestamp: addedTimestamp,
         closed: closed,
         isPending: isPending,
+        plannedWorkerIds: plannedWorkerIds,
       );
 
   static TaskPlanningElementDto fromDomain(TaskPlanningElement element) =>
@@ -112,5 +118,6 @@ class TaskPlanningElementDto extends GrafikElementDto {
         minutes: element.minutes,
         highPriority: element.highPriority,
         isPending: element.isPending,
+        plannedWorkerIds: List<String>.from(element.plannedWorkerIds),
       );
 }

--- a/domain/models/grafik/impl/task_element.dart
+++ b/domain/models/grafik/impl/task_element.dart
@@ -9,12 +9,6 @@ class TaskElement extends GrafikElement {
   final GrafikTaskType taskType;
   final List<String> carIds;
 
-  // ───────── TYLKO DO WIDOKU ─────────
-  /// Ilu pracowników pierwotnie planowano (przy konwersji z TaskPlanningElement).
-  final int? expectedWorkerCount;
-
-  /// Na ile minut pierwotnie planowano zadanie.
-  final int? plannedMinutes;
 
   TaskElement({
     required String id,
@@ -30,8 +24,6 @@ class TaskElement extends GrafikElement {
     required bool closed,
 
     // pola transient
-    this.expectedWorkerCount,
-    this.plannedMinutes,
   }) : super(
     id: id,
     startDateTime: startDateTime,
@@ -60,8 +52,6 @@ class TaskElement extends GrafikElement {
     String? addedByUserId,
     DateTime? addedTimestamp,
     bool? closed,
-    int? expectedWorkerCount,
-    int? plannedMinutes,
   }) {
     return TaskElement(
       id: id ?? this.id,
@@ -75,8 +65,6 @@ class TaskElement extends GrafikElement {
       addedByUserId: addedByUserId ?? this.addedByUserId,
       addedTimestamp: addedTimestamp ?? this.addedTimestamp,
       closed: closed ?? this.closed,
-      expectedWorkerCount: expectedWorkerCount ?? this.expectedWorkerCount,
-      plannedMinutes: plannedMinutes ?? this.plannedMinutes,
     );
   }
 
@@ -95,7 +83,5 @@ class TaskElement extends GrafikElement {
     addedByUserId: addedByUserId,
     addedTimestamp: addedTimestamp,
     closed: closed,
-    expectedWorkerCount: expectedWorkerCount,
-    plannedMinutes: plannedMinutes,
   );
 }

--- a/domain/models/grafik/impl/task_planning_element.dart
+++ b/domain/models/grafik/impl/task_planning_element.dart
@@ -9,6 +9,9 @@ class TaskPlanningElement extends GrafikElement {
   final int minutes;
   final bool highPriority;
 
+  /// Lista wstępnie planowanych pracowników
+  final List<String> plannedWorkerIds;
+
   /// WisiIGrozi – zadanie bez terminu
   final bool isPending;
 
@@ -27,6 +30,7 @@ class TaskPlanningElement extends GrafikElement {
     required DateTime addedTimestamp,
     required bool closed,
     this.isPending = false, // 👈 domyślnie nie wisi
+    this.plannedWorkerIds = const [],
   }) : super(
     id: id,
     startDateTime: startDateTime,

--- a/domain/models/grafik/impl/task_planning_to_task_extension.dart
+++ b/domain/models/grafik/impl/task_planning_to_task_extension.dart
@@ -26,10 +26,6 @@ extension ToTaskElement on TaskPlanningElement {
       addedByUserId: addedByUserId,
       addedTimestamp: DateTime.now(),
       closed: false,
-
-      // pola informacyjne
-      expectedWorkerCount: workerCount,
-      plannedMinutes: minutes,
     );
   }
 }

--- a/feature/grafik/form/strategy/task_planning_element_strategy.dart
+++ b/feature/grafik/form/strategy/task_planning_element_strategy.dart
@@ -32,6 +32,7 @@ class TaskPlanningElementStrategy implements GrafikElementFormStrategy {
       addedByUserId: '',
       addedTimestamp: DateTime.now(),
       closed: false,
+      plannedWorkerIds: const [],
     );
   }
 

--- a/feature/grafik/form/task_element_fields.dart
+++ b/feature/grafik/form/task_element_fields.dart
@@ -24,21 +24,6 @@ class TaskFields extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        // ───── info z planu ─────
-        if (element.expectedWorkerCount != null) ...[
-          Text(
-            'Planowano: ${element.expectedWorkerCount} pracowników',
-            style: const TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-        ],
-        if (element.plannedMinutes != null) ...[
-          Text(
-            'Planowany czas: ${element.plannedMinutes} min',
-            style: const TextStyle(fontStyle: FontStyle.italic),
-          ),
-          const SizedBox(height: 16),
-        ],
         const TaskTemplatesRow(),
         // Order ID
         CustomTextField(

--- a/feature/grafik/form/task_planning_element_fields.dart
+++ b/feature/grafik/form/task_planning_element_fields.dart
@@ -12,7 +12,9 @@ import '../../../shared/form/small_number_picker/small_number_picker.dart';
 import '../../../domain/constants/pending_placeholder_date.dart';
 import '../cubit/form/grafik_element_form_cubit.dart';
 import '../cubit/form/grafik_element_form_state.dart';
-import 'components/assignment_editor.dart';
+import '../../employee/employee_picker.dart';
+import 'package:get_it/get_it.dart';
+import '../../../../data/repositories/employee_repository.dart';
 
 class GrafikPlanningFields extends StatelessWidget {
   final TaskPlanningElement element;
@@ -101,14 +103,14 @@ class GrafikPlanningFields extends StatelessWidget {
               context.read<GrafikElementFormCubit>().updateField('highPriority', val),
         ),
         const SizedBox(height: AppSpacing.sm * 2),
-        BlocBuilder<GrafikElementFormCubit, GrafikElementFormState>(
-          builder: (context, state) {
-            if (state is! GrafikElementFormEditing) return const SizedBox.shrink();
-            return AssignmentEditor(
-              taskStart: state.element.startDateTime,
-              taskEnd: state.element.endDateTime,
-              assignments: state.assignments,
-            );
+        EmployeePicker(
+          employeeStream: GetIt.I<EmployeeRepository>().getEmployees(),
+          initialSelectedIds: element.plannedWorkerIds,
+          onSelectionChanged: (employees) {
+            final ids = employees.map((e) => e.uid).toList();
+            context
+                .read<GrafikElementFormCubit>()
+                .updateField('plannedWorkerIds', ids);
           },
         ),
       ],

--- a/feature/grafik/widget/dialog/grafik_element_popup.dart
+++ b/feature/grafik/widget/dialog/grafik_element_popup.dart
@@ -113,7 +113,7 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
             if (_element is DeliveryPlanningElement)
               ..._buildDeliveryPlanningDetails(_element as DeliveryPlanningElement),
             if (_element is TaskPlanningElement)
-              ..._buildTaskPlanningDetails(_element as TaskPlanningElement),
+              ..._buildTaskPlanningDetails(context, _element as TaskPlanningElement),
             if (_element is TimeIssueElement)
               ..._buildTimeIssueDetails(_element as TimeIssueElement),
             if (_element is TaskElement) ...[
@@ -220,14 +220,23 @@ class _GrafikElementPopupState extends State<GrafikElementPopup> {
         Text('Category: ${delivery.category.name}'),
       ];
 
-  List<Widget> _buildTaskPlanningDetails(TaskPlanningElement planning) => [
-    Text('Worker Count: ${planning.workerCount}'),
-    Text('Order ID: ${planning.orderId}'),
-    Text('Probability: ${planning.probability.name}'),
-    Text('Task Type: ${planning.taskType.name}'),
-    Text('Minutes: ${planning.minutes}'),
-    Text('Pilne: ${planning.highPriority ? 'Tak' : 'Nie'}'),
-  ];
+  List<Widget> _buildTaskPlanningDetails(BuildContext context, TaskPlanningElement planning) {
+    final employees = context.read<GrafikCubit>().state.employees
+        .where((e) => planning.plannedWorkerIds.contains(e.uid))
+        .toList();
+    final names = employees.isNotEmpty
+        ? employees.map((e) => e.formattedNameWithSecondInitial).join(', ')
+        : 'Brak';
+    return [
+      Text('Pracownicy: $names'),
+      Text('Worker Count: ${planning.workerCount}'),
+      Text('Order ID: ${planning.orderId}'),
+      Text('Probability: ${planning.probability.name}'),
+      Text('Task Type: ${planning.taskType.name}'),
+      Text('Minutes: ${planning.minutes}'),
+      Text('Pilne: ${planning.highPriority ? 'Tak' : 'Nie'}'),
+    ];
+  }
 
   List<Widget> _buildTimeIssueDetails(TimeIssueElement issue) => [
     Text('Reason: ${issue.issueType}'),

--- a/feature/grafik/widget/pending_task_column.dart
+++ b/feature/grafik/widget/pending_task_column.dart
@@ -16,9 +16,12 @@ class PendingTasksColumn extends StatelessWidget {
     GrafikState state,
     TaskPlanningElement taskPlanning,
   ) {
-    return const GrafikElementData(
-      assignedEmployees: [],
-      assignedVehicles: [],
+    final employees = state.employees
+        .where((e) => taskPlanning.plannedWorkerIds.contains(e.uid))
+        .toList();
+    return GrafikElementData(
+      assignedEmployees: employees,
+      assignedVehicles: const [],
     );
   }
 

--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -35,10 +35,16 @@ class ForegroundLayer extends StatelessWidget {
     );
   }
 
-  GrafikElementData _taskPlanningData(GrafikState state) {
-    return const GrafikElementData(
-      assignedEmployees: [],
-      assignedVehicles: [],
+  GrafikElementData _taskPlanningData(
+    GrafikState state,
+    TaskPlanningElement taskPlanning,
+  ) {
+    final employees = state.employees
+        .where((e) => taskPlanning.plannedWorkerIds.contains(e.uid))
+        .toList();
+    return GrafikElementData(
+      assignedEmployees: employees,
+      assignedVehicles: const [],
     );
   }
 
@@ -81,7 +87,7 @@ class ForegroundLayer extends StatelessWidget {
             if (elem is TaskPlanningElement) {
               return TaskPlanningWeekTile(
                 taskPlanning: elem,
-                data: _taskPlanningData(state),
+                data: _taskPlanningData(state, elem),
               );
             } else if (elem is DeliveryPlanningElement) {
               return DeliveryPlanningWeekTile(


### PR DESCRIPTION
## Summary
- remove expected worker count and planned minutes from `TaskElement`
- keep planning info in `TaskPlanningElement` only
- store preliminarily assigned workers in `TaskPlanningElement`
- adjust DTOs, forms and widgets for the new field

## Testing
- `apt-get update`
- `apt-get install` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6872c20d5d3883339740596d991d91a2