### PR TITLE
Add badge overlay to GrafikElementCard

### DIFF
--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -108,6 +108,8 @@ class GrafikElementCard extends StatelessWidget {
 
 
 
+        final showBadge = style.badgeIcon != null && remaining > variant.iconSize;
+
         return SizedBox.expand(
           child: Container(
             decoration: BoxDecoration(
@@ -150,6 +152,16 @@ class GrafikElementCard extends StatelessWidget {
                     ),
                   ],
                 ),
+                if (showBadge)
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: Icon(
+                      style.badgeIcon!,
+                      size: variant.iconSize,
+                      color: style.badgeColor,
+                    ),
+                  ),
                 if (statusIcon != null)
                   Positioned(
                     right: 0,


### PR DESCRIPTION
## Summary
- show optional badge on GrafikElementCard
- check for space before rendering the badge

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f13390dc83339d15123f20cf3f07