### PR TITLE
Add Flutter analysis options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: false


### PR DESCRIPTION
## Summary
- add root `analysis_options.yaml` and disable `avoid_print`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873faa11d18833384254b0f1e4e0211