### PR TITLE
Remove redundant import

### DIFF
--- a/shared/turbo_grid/turbo_grid.dart
+++ b/shared/turbo_grid/turbo_grid.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'turbo_tile.dart'; // <-- popraw ścieżkę jeśli masz inny układ folderów
 
 /// TurboGrid – widget układający dynamicznie kafelki (TurboTile) w dostępnej przestrzeni,
 /// przyjmując listę kafelków w konstruktorze. Nie zmieniamy nazwy, parametrów ani nic innego.


### PR DESCRIPTION
## Summary
- clean up `turbo_grid.dart` by removing the commented `turbo_tile.dart` import

## Testing
- `flutter analyze` *(fails: many undefined identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_6874013b831083338dc005a9982e2150