### PR TITLE
Fix flex constraints in GrafikElementCard

### DIFF
--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -153,9 +153,10 @@ class GrafikElementCard extends StatelessWidget {
                           color: style.borderColor,
                         ),
                       ),
-                    Expanded(
+                    Flexible(
+                      fit: FlexFit.loose,
                       child: Column(
-                        mainAxisSize: MainAxisSize.max,
+                        mainAxisSize: MainAxisSize.min,
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           ...children,


### PR DESCRIPTION
## Summary
- use a loose `Flexible` instead of an `Expanded`

## Testing
- `flutter analyze` *(fails: 3112 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68740817c100833397fdf5d30e12afc0