### PR TITLE
Fix unbounded flex layout

### DIFF
--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -160,7 +160,6 @@ class GrafikElementCard extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           ...children,
-                          const Spacer(),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Summary
- remove `Spacer` from `GrafikElementCard` to avoid flex layout errors

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740d0bdcbc83338083b166a1da04aa