### PR TITLE
Center login screen

### DIFF
--- a/feature/auth/screen/login_screen.dart
+++ b/feature/auth/screen/login_screen.dart
@@ -28,17 +28,18 @@ class LoginScreen extends StatelessWidget {
         body: LayoutBuilder(
           builder: (context, constraints) {
             return SingleChildScrollView(
-              child: ResponsivePadding(
-                small: EdgeInsets.all(AppSpacing.sm * 4),
-                medium: EdgeInsets.all(AppSpacing.sm * 6),
-                large: EdgeInsets.all(AppSpacing.sm * 8),
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    minHeight: constraints.maxHeight,
-                    maxWidth: 400,
-                  ),
-                child: Center(
-                  child: Column(
+              child: Center(
+                child: ResponsivePadding(
+                  small: EdgeInsets.all(AppSpacing.sm * 4),
+                  medium: EdgeInsets.all(AppSpacing.sm * 6),
+                  large: EdgeInsets.all(AppSpacing.sm * 8),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: constraints.maxHeight,
+                      maxWidth: 400,
+                    ),
+                    child: Center(
+                      child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Image.asset(


### PR DESCRIPTION
## Summary
- wrap login screen in an extra `Center` widget to center on larger screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687417b6e90083338e1a38e03f2c968b