### PR TITLE
Adjust text scaling for tablets

### DIFF
--- a/theme/app_tokens.dart
+++ b/theme/app_tokens.dart
@@ -15,7 +15,9 @@ class AppSpacing {
     final shortSide =
         math.min(view.physicalSize.width, view.physicalSize.height) /
             view.devicePixelRatio;
-    final factor = shortSide >= 600 ? 2.0 : 1.0;
+    final factor = shortSide >= 600
+        ? (shortSide / 600).clamp(1.2, 1.6)
+        : 1.0;
     switch (bp) {
       case Breakpoint.small:
         return 1.0 * factor;

--- a/theme/size_variants.dart
+++ b/theme/size_variants.dart
@@ -12,7 +12,10 @@ extension SizeVariantSpec on SizeVariant {
         math.min(view.physicalSize.width, view.physicalSize.height) /
             view.devicePixelRatio;
     final base = (width / 400).clamp(0.8, 1.2);
-    return shortSide >= 600 ? 2.0 : base;
+    if (shortSide >= 600) {
+      return (shortSide / 600).clamp(1.2, 1.6);
+    }
+    return base;
   }
 
   /// Wysokość kafelka ‑ **musi być taka sama** we wszystkich delegatach.

--- a/theme/theme.dart
+++ b/theme/theme.dart
@@ -5,12 +5,18 @@ import 'color_schemes.dart';
 import 'package:kabast/shared/responsive/responsive_layout.dart';
 
 class AppTheme {
-  static bool _largeScreen() {
+  static double _deviceScale() {
     final view = WidgetsBinding.instance.platformDispatcher.views.first;
+    final width = view.physicalSize.width / view.devicePixelRatio;
     final shortest =
         math.min(view.physicalSize.width, view.physicalSize.height) /
             view.devicePixelRatio;
-    return shortest >= 600;
+
+    if (shortest >= 600) {
+      return (shortest / 600).clamp(1.2, 1.6);
+    }
+
+    return (width / 400).clamp(0.8, 1.2);
   }
 
   static double _scaleFor(Breakpoint bp) {
@@ -25,25 +31,23 @@ class AppTheme {
   }
 
   static TextStyle textStyleFor(Breakpoint bp, TextStyle style) {
-    final scale = _largeScreen() ? 2.0 : _scaleFor(bp);
+    final scale = _deviceScale();
+    final base = _scaleFor(bp);
+    final value = math.max(base, scale);
     return style.copyWith(
-      fontSize: style.fontSize != null ? style.fontSize! * scale : null,
+      fontSize: style.fontSize != null ? style.fontSize! * value : null,
     );
   }
 
   /// Scales arbitrary size values according to the current [Breakpoint].
   static double sizeFor(Breakpoint bp, double size) {
-    final scale = _largeScreen() ? 2.0 : _scaleFor(bp);
-    return size * scale;
+    final scale = _deviceScale();
+    final base = _scaleFor(bp);
+    final value = math.max(base, scale);
+    return size * value;
   }
   static ThemeData buildTheme() {
-    final view = WidgetsBinding.instance.platformDispatcher.views.first;
-    final width = view.physicalSize.width / view.devicePixelRatio;
-    final shortSide =
-        math.min(view.physicalSize.width, view.physicalSize.height) /
-            view.devicePixelRatio;
-    final base = (width / 400).clamp(0.8, 1.2);
-    final scale = shortSide >= 600 ? 2.0 : base;
+    final scale = _deviceScale();
 
     final scheme = lightColorScheme;
     return ThemeData(


### PR DESCRIPTION
## Summary
- add `_deviceScale` to compute dynamic scaling
- use dynamic scale in `textStyleFor` and `sizeFor`
- apply same logic in `buildTheme`
- update spacing and size variants to use new tablet scaling

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_687417bd743883339b5018fe3d63a09f