### PR TITLE
Color single-day tasks by type

### DIFF
--- a/feature/grafik/constants/enums_ui.dart
+++ b/feature/grafik/constants/enums_ui.dart
@@ -29,4 +29,18 @@ extension GrafikTaskTypeX on GrafikTaskType {
         return Icons.more_horiz;
     }
   }
+
+  /// Color of task card border for daily view.
+  Color get borderColor {
+    switch (this) {
+      case GrafikTaskType.Produkcja:
+        return Colors.blue;
+      case GrafikTaskType.Budowa:
+        return Colors.yellow;
+      case GrafikTaskType.Serwis:
+        return Colors.green;
+      case GrafikTaskType.Inne:
+        return Colors.grey;
+    }
+  }
 }

--- a/feature/grafik/widget/task/task_list.dart
+++ b/feature/grafik/widget/task/task_list.dart
@@ -160,6 +160,7 @@ class TaskList extends StatelessWidget {
                         element: task,
                         data: data,
                         variant: variant,
+                        useTaskTypeBorderColor: true,
                       );
                     },
                   );

--- a/shared/grafik_element_card.dart
+++ b/shared/grafik_element_card.dart
@@ -21,17 +21,28 @@ class GrafikElementCard extends StatelessWidget {
   final GrafikElement element;
   final GrafikElementData data;
   final SizeVariant variant;
+  final bool useTaskTypeBorderColor;
 
   const GrafikElementCard({
     super.key,
     required this.element,
     required this.data,
     required this.variant,
+    this.useTaskTypeBorderColor = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    final style = const GrafikElementStyleResolver().styleFor(element.type);
+    GrafikElementStyle style =
+        const GrafikElementStyleResolver().styleFor(element.type);
+    if (useTaskTypeBorderColor && element is TaskElement) {
+      style = GrafikElementStyle(
+        backgroundColor: style.backgroundColor,
+        borderColor: (element as TaskElement).taskType.borderColor,
+        badgeIcon: style.badgeIcon,
+        badgeColor: style.badgeColor,
+      );
+    }
     final delegate = GrafikElementCardDelegateRegistry.delegateFor(element);
 
     final label = delegate.getLabel();


### PR DESCRIPTION
## Summary
- extend `GrafikTaskTypeX` with color mapping
- allow `GrafikElementCard` to override border colour by task type
- apply the override in daily `TaskList`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874192375ec83338b71cf2ce1b21dea