### PR TITLE
Implement template task tiles

### DIFF
--- a/feature/grafik/widget/task/template_task_card.dart
+++ b/feature/grafik/widget/task/template_task_card.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import '../../../../domain/models/grafik/impl/task_element.dart';
+import '../../../../shared/responsive/responsive_layout.dart';
+import '../../../../theme/app_tokens.dart';
+import '../../../../theme/theme.dart';
+
+class TemplateTaskCard extends StatelessWidget {
+  final TaskElement task;
+  const TemplateTaskCard({super.key, required this.task});
+
+  @override
+  Widget build(BuildContext context) {
+    final bp = context.breakpoint;
+    final style = AppTheme.textStyleFor(
+      bp,
+      Theme.of(context).textTheme.bodyMedium!,
+    );
+    return Container(
+      padding: EdgeInsets.all(AppSpacing.scaled(AppSpacing.sm, bp)),
+      decoration: BoxDecoration(
+        color: Colors.pink.shade50,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        border: Border.all(color: Colors.pink.shade200),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Icon(Icons.auto_awesome, color: Colors.pink),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Text(
+              task.additionalInfo,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: style,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `TemplateTaskCard` widget for standard tasks
- replace `StandardTaskRow` with a responsive tile layout

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753155eeb08333a984f20257da9c36