### PR TITLE
Use constant for standard order filtering

### DIFF
--- a/domain/models/grafik/impl/task_template.dart
+++ b/domain/models/grafik/impl/task_template.dart
@@ -5,6 +5,9 @@
 ///
 import '../enums.dart';
 
+/// Order id used for tasks considered "standard" and listed separately.
+const String kStandardOrderId = '0001';
+
 class TaskTemplate {
   final String label;
   final GrafikTaskType taskType;
@@ -33,7 +36,7 @@ const kTaskTemplates = <TaskTemplate>[
     label: 'SZADO',
     taskType: GrafikTaskType.Inne,
     status: GrafikStatus.Realizacja,
-    orderId: '0001',
+    orderId: kStandardOrderId,
     carIds: [],
     startHour: 7,
     endHour: 15,
@@ -43,7 +46,7 @@ const kTaskTemplates = <TaskTemplate>[
     label: 'KRAWCZYK',
     taskType: GrafikTaskType.Inne,
     status: GrafikStatus.Realizacja,
-    orderId: '0001',
+    orderId: kStandardOrderId,
     carIds: ['QqYtL81vjbmpi6859Q9Y'],
     startHour: 7,
     endHour: 15,

--- a/feature/grafik/widget/task/task_list.dart
+++ b/feature/grafik/widget/task/task_list.dart
@@ -14,6 +14,7 @@ import 'package:kabast/shared/grafik_element_card.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
 import 'package:kabast/shared/utils/tile_size_resolver.dart';
+import 'package:kabast/domain/models/grafik/impl/task_template.dart';
 
 class TaskList extends StatelessWidget {
   final DateTime date;
@@ -91,9 +92,9 @@ class TaskList extends StatelessWidget {
         }
 
         final standardTasks =
-            tasks.where((task) => task.orderId == "0001").toList();
+            tasks.where((t) => t.orderId.trim() == kStandardOrderId).toList();
         final nonStandardTasks =
-            tasks.where((task) => task.orderId != "0001").toList();
+            tasks.where((t) => t.orderId.trim() != kStandardOrderId).toList();
 
         final List<Widget> children = [
           Column(


### PR DESCRIPTION
## Summary
- centralize `'0001'` order id as `kStandardOrderId`
- import the constant in task list widget
- filter tasks by trimmed `orderId`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687540b0480c83339906b7bec769a5aa