### PR TITLE
Add widget test for StandardTaskRow

### DIFF
--- a/test/feature/grafik/standard_task_row_test.dart
+++ b/test/feature/grafik/standard_task_row_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:kabast/feature/grafik/form/standard_task_row.dart';
+import 'package:kabast/feature/grafik/widget/task/template_task_card.dart';
+import 'package:kabast/domain/models/grafik/impl/task_element.dart';
+import 'package:kabast/domain/models/grafik/impl/task_template.dart';
+import 'package:kabast/domain/models/grafik/enums.dart';
+
+void main() {
+  testWidgets('renders TemplateTaskCard for each standard task', (tester) async {
+    final tasks = [
+      TaskElement(
+        id: '1',
+        startDateTime: DateTime(2023, 1, 1, 8),
+        endDateTime: DateTime(2023, 1, 1, 9),
+        additionalInfo: 'test1',
+        orderId: kStandardOrderId,
+        status: GrafikStatus.Realizacja,
+        taskType: GrafikTaskType.Inne,
+        carIds: const [],
+        addedByUserId: 'u1',
+        addedTimestamp: DateTime(2023, 1, 1),
+        closed: false,
+      ),
+      TaskElement(
+        id: '2',
+        startDateTime: DateTime(2023, 1, 1, 10),
+        endDateTime: DateTime(2023, 1, 1, 11),
+        additionalInfo: 'test2',
+        orderId: kStandardOrderId,
+        status: GrafikStatus.Realizacja,
+        taskType: GrafikTaskType.Inne,
+        carIds: const [],
+        addedByUserId: 'u1',
+        addedTimestamp: DateTime(2023, 1, 1),
+        closed: false,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(home: StandardTaskRow(standardTasks: tasks)),
+    );
+
+    expect(find.byType(TemplateTaskCard), findsNWidgets(tasks.length));
+  });
+}


### PR DESCRIPTION
## Summary
- add a widget test verifying `StandardTaskRow` shows a `TemplateTaskCard` for each task

## Testing
- `flutter test test/feature/grafik/standard_task_row_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687541d30c388333b29b16c61a117c70