### PR TITLE
Add SupplyRunElement model

### DIFF
--- a/data/dto/grafik/grafik_element_dto.dart
+++ b/data/dto/grafik/grafik_element_dto.dart
@@ -5,11 +5,13 @@ import '../../../domain/models/grafik/impl/task_element.dart';
 import '../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
+import '../../../domain/models/grafik/impl/supply_run_element.dart';
 import '../../../domain/models/grafik/enums.dart';
 import 'task_element_dto.dart';
 import 'time_issue_element_dto.dart';
 import 'delivery_planning_element_dto.dart';
 import 'task_planning_element_dto.dart';
+import 'supply_run_element_dto.dart';
 
 abstract class GrafikElementDto {
   static DateTime parseDateTime(dynamic value, DateTime fallback) {
@@ -67,6 +69,9 @@ abstract class GrafikElementDto {
       case 'DeliveryPlanningElement':
         return DeliveryPlanningElementDto.fromDomain(
             element as DeliveryPlanningElement);
+      case 'SupplyRunElement':
+        return SupplyRunElementDto.fromDomain(
+            element as SupplyRunElement);
       case 'TaskPlanningElement':
         return TaskPlanningElementDto.fromDomain(
             element as TaskPlanningElement);
@@ -84,6 +89,8 @@ abstract class GrafikElementDto {
         return TimeIssueElementDto.fromJson(json);
       case 'DeliveryPlanningElement':
         return DeliveryPlanningElementDto.fromJson(json);
+      case 'SupplyRunElement':
+        return SupplyRunElementDto.fromJson(json);
       case 'TaskPlanningElement':
         return TaskPlanningElementDto.fromJson(json);
       default:

--- a/data/dto/grafik/supply_run_element_dto.dart
+++ b/data/dto/grafik/supply_run_element_dto.dart
@@ -1,0 +1,81 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../domain/models/grafik/impl/supply_run_element.dart';
+import 'grafik_element_dto.dart';
+
+class SupplyRunElementDto extends GrafikElementDto {
+  final List<String> supplyOrderIds;
+  final String routeDescription;
+
+  SupplyRunElementDto({
+    required super.id,
+    required super.startDateTime,
+    required super.endDateTime,
+    required super.type,
+    required super.additionalInfo,
+    required super.addedByUserId,
+    required super.addedTimestamp,
+    required super.closed,
+    required this.supplyOrderIds,
+    required this.routeDescription,
+  });
+
+  factory SupplyRunElementDto.fromJson(Map<String, dynamic> json) {
+    return SupplyRunElementDto(
+      id: json['id'] as String? ?? '',
+      startDateTime: GrafikElementDto.parseDateTime(
+        json['startDateTime'],
+        DateTime.now(),
+      ),
+      endDateTime: GrafikElementDto.parseDateTime(
+        json['endDateTime'],
+        DateTime.now(),
+      ),
+      type: 'SupplyRunElement',
+      additionalInfo: json['additionalInfo'] as String? ?? '',
+      addedByUserId: json['addedByUserId'] as String? ?? '',
+      addedTimestamp: GrafikElementDto.parseDateTime(
+        json['addedTimestamp'],
+        DateTime(1960, 2, 9),
+      ),
+      closed: json['closed'] as bool? ?? false,
+      supplyOrderIds:
+          (json['supplyOrderIds'] as List?)?.cast<String>() ?? const <String>[],
+      routeDescription: json['routeDescription'] as String? ?? '',
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ...baseToJson(),
+        'supplyOrderIds': supplyOrderIds,
+        'routeDescription': routeDescription,
+      };
+
+  @override
+  SupplyRunElement toDomain() => SupplyRunElement(
+        id: id,
+        startDateTime: startDateTime,
+        endDateTime: endDateTime,
+        additionalInfo: additionalInfo,
+        supplyOrderIds: supplyOrderIds,
+        routeDescription: routeDescription,
+        addedByUserId: addedByUserId,
+        addedTimestamp: addedTimestamp,
+        closed: closed,
+      );
+
+  static SupplyRunElementDto fromDomain(SupplyRunElement element) =>
+      SupplyRunElementDto(
+        id: element.id,
+        startDateTime: element.startDateTime,
+        endDateTime: element.endDateTime,
+        type: element.type,
+        additionalInfo: element.additionalInfo,
+        addedByUserId: element.addedByUserId,
+        addedTimestamp: element.addedTimestamp,
+        closed: element.closed,
+        supplyOrderIds: List<String>.from(element.supplyOrderIds),
+        routeDescription: element.routeDescription,
+      );
+}

--- a/domain/models/grafik/impl/supply_run_element.dart
+++ b/domain/models/grafik/impl/supply_run_element.dart
@@ -1,0 +1,64 @@
+import '../grafik_element.dart';
+
+/// Element planowanej trasy zaopatrzenia tworzony przez użytkownika.
+class SupplyRunElement extends GrafikElement {
+  final List<String> supplyOrderIds;
+  final String routeDescription;
+
+  SupplyRunElement({
+    required String id,
+    required DateTime startDateTime,
+    required DateTime endDateTime,
+    required String additionalInfo,
+    required this.supplyOrderIds,
+    required this.routeDescription,
+    required String addedByUserId,
+    required DateTime addedTimestamp,
+    bool closed = false,
+  }) : super(
+          id: id,
+          startDateTime: startDateTime,
+          endDateTime: endDateTime,
+          type: 'SupplyRunElement',
+          additionalInfo: additionalInfo,
+          addedByUserId: addedByUserId,
+          addedTimestamp: addedTimestamp,
+          closed: closed,
+        );
+
+  SupplyRunElement copyWith({
+    String? id,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
+    String? additionalInfo,
+    List<String>? supplyOrderIds,
+    String? routeDescription,
+    String? addedByUserId,
+    DateTime? addedTimestamp,
+    bool? closed,
+  }) {
+    return SupplyRunElement(
+      id: id ?? this.id,
+      startDateTime: startDateTime ?? this.startDateTime,
+      endDateTime: endDateTime ?? this.endDateTime,
+      additionalInfo: additionalInfo ?? this.additionalInfo,
+      supplyOrderIds: supplyOrderIds ?? List<String>.from(this.supplyOrderIds),
+      routeDescription: routeDescription ?? this.routeDescription,
+      addedByUserId: addedByUserId ?? this.addedByUserId,
+      addedTimestamp: addedTimestamp ?? this.addedTimestamp,
+      closed: closed ?? this.closed,
+    );
+  }
+
+  SupplyRunElement copyWithId(String newId) => SupplyRunElement(
+        id: newId,
+        startDateTime: startDateTime,
+        endDateTime: endDateTime,
+        additionalInfo: additionalInfo,
+        supplyOrderIds: List<String>.from(supplyOrderIds),
+        routeDescription: routeDescription,
+        addedByUserId: addedByUserId,
+        addedTimestamp: addedTimestamp,
+        closed: closed,
+      );
+}

--- a/feature/grafik/constants/element_styles.dart
+++ b/feature/grafik/constants/element_styles.dart
@@ -36,6 +36,11 @@ class GrafikElementStyleResolver {
           backgroundColor: Colors.orange.shade100,
           borderColor: Colors.orange,
         );
+      case 'SupplyRunElement':
+        return GrafikElementStyle(
+          backgroundColor: Colors.purple.shade100,
+          borderColor: Colors.purple,
+        );
       case 'TimeIssueElement':
         return GrafikElementStyle(
           backgroundColor: Colors.red.shade100,

--- a/shared/grafik_card_delegate.dart
+++ b/shared/grafik_card_delegate.dart
@@ -3,6 +3,7 @@ import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart'
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
+import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
 
 abstract class GrafikElementCardDelegate {
   String getLabel();
@@ -52,6 +53,20 @@ class DeliveryPlanningElementCardDelegate implements GrafikElementCardDelegate {
   String getDescription() => delivery.additionalInfo;
 }
 
+class SupplyRunElementCardDelegate implements GrafikElementCardDelegate {
+  final SupplyRunElement run;
+  SupplyRunElementCardDelegate(this.run);
+
+  @override
+  String getLabel() => run.routeDescription;
+
+  @override
+  String getTimeInfo() => _formatTime(run.startDateTime, run.endDateTime);
+
+  @override
+  String getDescription() => run.additionalInfo;
+}
+
 class TimeIssueElementCardDelegate implements GrafikElementCardDelegate {
   final TimeIssueElement issue;
   TimeIssueElementCardDelegate(this.issue);
@@ -75,6 +90,8 @@ class GrafikElementCardDelegateRegistry {
         return TaskPlanningElementCardDelegate(element as TaskPlanningElement);
       case DeliveryPlanningElement:
         return DeliveryPlanningElementCardDelegate(element as DeliveryPlanningElement);
+      case SupplyRunElement:
+        return SupplyRunElementCardDelegate(element as SupplyRunElement);
       case TimeIssueElement:
         return TimeIssueElementCardDelegate(element as TimeIssueElement);
       default:


### PR DESCRIPTION
## Summary
- introduce `SupplyRunElement` model and DTO
- support `SupplyRunElement` in grafik DTO conversions
- add card delegate and style for supply runs

## Testing
- `git status --short`
- `dart` was not available, so formatting/tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6876abac9854833387eced8f3104bded