### PR TITLE
Register SupplyRunElement

### DIFF
--- a/feature/grafik/form/components/type_dropdown.dart
+++ b/feature/grafik/form/components/type_dropdown.dart
@@ -17,6 +17,7 @@ class TypeDropdown extends StatelessWidget {
       'TaskPlanningElement': 'Planowane zadanie',
       'TimeIssueElement': 'Czas Pracy',
       'DeliveryPlanningElement': 'Dostawa',
+      'SupplyRunElement': 'Trasa zaopatrzenia',
     };
 
     return Row(

--- a/feature/grafik/form/grafik_element_registry.dart
+++ b/feature/grafik/form/grafik_element_registry.dart
@@ -4,14 +4,17 @@ import 'delivery_planning_element_fields.dart';
 import 'task_element_fields.dart';
 import 'task_planning_element_fields.dart';
 import 'time_issue_element_fields.dart';
+import 'supply_run_element_fields.dart';
 import 'strategy/delivery_planning_element_strategy.dart';
 import 'strategy/task_element_strategy.dart';
 import 'strategy/task_planning_element_strategy.dart';
 import 'strategy/time_issue_element_strategy.dart';
+import 'strategy/supply_run_element_strategy.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../../domain/models/grafik/impl/time_issue_element.dart';
+import '../../../domain/models/grafik/impl/supply_run_element.dart';
 import '../../../domain/models/grafik/grafik_element.dart';
 import 'strategy/grafik_element_form_strategy.dart';
 
@@ -23,6 +26,7 @@ class GrafikElementRegistry {
     'DeliveryPlanningElement': (e) => DeliveryPlanningFields(element: e as DeliveryPlanningElement),
     'TaskElement': (e) => TaskFields(element: e as TaskElement),
     'TaskPlanningElement': (e) => GrafikPlanningFields(element: e as TaskPlanningElement),
+    'SupplyRunElement': (e) => SupplyRunFields(element: e as SupplyRunElement),
   };
 
   static final Map<String, GrafikElementFormStrategy> _strategies = {
@@ -30,6 +34,7 @@ class GrafikElementRegistry {
     'DeliveryPlanningElement': DeliveryPlanningElementStrategy(),
     'TaskElement': TaskElementStrategy(),
     'TaskPlanningElement': TaskPlanningElementStrategy(),
+    'SupplyRunElement': SupplyRunElementStrategy(),
   };
 
 

--- a/feature/grafik/form/strategy/supply_run_element_strategy.dart
+++ b/feature/grafik/form/strategy/supply_run_element_strategy.dart
@@ -1,0 +1,52 @@
+import '../grafik_element_form_adapter.dart';
+import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../injection.dart';
+import '../../../../domain/models/grafik/grafik_element.dart';
+import '../../../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../../../domain/models/grafik/impl/task_template.dart';
+import 'grafik_element_form_strategy.dart';
+import '../../../../data/repositories/task_assignment_repository.dart';
+import '../../../../domain/models/grafik/task_assignment.dart';
+
+class SupplyRunElementStrategy implements GrafikElementFormStrategy {
+  final GrafikElementFormAdapter _adapter =
+      GrafikElementFormAdapter(repo: getIt<GrafikElementRepository>());
+
+  @override
+  GrafikElement createDefault() {
+    final tomorrow = DateTime.now().add(const Duration(days: 1));
+    final start = DateTime(tomorrow.year, tomorrow.month, tomorrow.day, 7);
+    final end = DateTime(tomorrow.year, tomorrow.month, tomorrow.day, 15);
+    return SupplyRunElement(
+      id: '',
+      startDateTime: start,
+      endDateTime: end,
+      additionalInfo: '',
+      supplyOrderIds: const [],
+      routeDescription: '',
+      addedByUserId: '',
+      addedTimestamp: DateTime.now(),
+      closed: false,
+    );
+  }
+
+  @override
+  GrafikElement updateField(GrafikElement element, String field, dynamic value) {
+    return _adapter.updateField(element, field, value);
+  }
+
+  @override
+  GrafikElement applyTemplate(GrafikElement element, TaskTemplate template) {
+    return element;
+  }
+
+  @override
+  Future<void> save(
+    GrafikElementRepository repo,
+    GrafikElement element, {
+    TaskAssignmentRepository? assignmentRepository,
+    List<TaskAssignment> assignments = const [],
+  }) async {
+    await repo.saveGrafikElement(element);
+  }
+}

--- a/feature/grafik/form/supply_run_element_fields.dart
+++ b/feature/grafik/form/supply_run_element_fields.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../../shared/form/custom_textfield.dart';
+import '../cubit/form/grafik_element_form_cubit.dart';
+import '../../../theme/app_tokens.dart';
+
+class SupplyRunFields extends StatelessWidget {
+  final SupplyRunElement element;
+
+  const SupplyRunFields({Key? key, required this.element}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        CustomTextField(
+          label: 'Opis trasy',
+          initialValue: element.routeDescription,
+          onChanged: (val) =>
+              context.read<GrafikElementFormCubit>().updateField('routeDescription', val),
+        ),
+        const SizedBox(height: AppSpacing.sm * 2),
+        CustomTextField(
+          label: 'ID zamówień (oddzielone przecinkami)',
+          initialValue: element.supplyOrderIds.join(', '),
+          onChanged: (val) {
+            final ids = val
+                .split(',')
+                .map((e) => e.trim())
+                .where((e) => e.isNotEmpty)
+                .toList();
+            context.read<GrafikElementFormCubit>().updateField('supplyOrderIds', ids);
+          },
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add SupplyRunFields for form
- implement SupplyRunElementStrategy
- register SupplyRunElement in GrafikElementRegistry and UI dropdown

## Testing
- `No tests run (dart unavailable)`

------
https://chatgpt.com/codex/tasks/task_e_6877c77a557083339132806dee61a570