### PR TITLE
Implement SupplyRunPlanningCubit

### DIFF
--- a/data/repositories/supply_firebase_repository.dart
+++ b/data/repositories/supply_firebase_repository.dart
@@ -43,4 +43,9 @@ class SupplyFirebaseRepository implements ISupplyRepository {
     return _orders.snapshots().map((query) =>
         query.docs.map((doc) => SupplyOrderDto.fromFirestore(doc).toDomain()).toList());
   }
+
+  @override
+  Future<void> updateOrderStatus(String id, String status) async {
+    await _orders.doc(id).update({'status': status});
+  }
 }

--- a/domain/services/i_supply_repository.dart
+++ b/domain/services/i_supply_repository.dart
@@ -8,4 +8,6 @@ abstract class ISupplyRepository {
   Future<void> placeOrder(SupplyOrder order);
 
   Stream<List<SupplyOrder>> watchOrders();
+
+  Future<void> updateOrderStatus(String id, String status);
 }

--- a/feature/supplies/cubit/supply_run_planning_cubit.dart
+++ b/feature/supplies/cubit/supply_run_planning_cubit.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../../domain/models/supply_order.dart';
+import '../../../data/repositories/grafik_element_repository.dart';
+import '../../../domain/services/i_supply_repository.dart';
+import 'supply_run_planning_state.dart';
+
+class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
+  final ISupplyRepository _supplyRepository;
+  final GrafikElementRepository _grafikRepository;
+  SupplyRunPlanningCubit(
+    this._supplyRepository,
+    this._grafikRepository,
+  ) : super(SupplyRunPlanningState.initial());
+
+  Stream<List<SupplyOrder>> streamSupplyOrders() {
+    return _supplyRepository
+        .watchOrders()
+        .map((orders) => orders.where((o) => o.status == 'pending').toList());
+  }
+
+  void toggleSelection(String orderId) {
+    final newSet = Set<String>.from(state.selectedIds);
+    if (newSet.contains(orderId)) {
+      newSet.remove(orderId);
+    } else {
+      newSet.add(orderId);
+    }
+    emit(state.copyWith(selectedIds: newSet));
+  }
+
+  void setRouteDescription(String desc) {
+    emit(state.copyWith(routeDescription: desc));
+  }
+
+  void setAdditionalInfo(String info) {
+    emit(state.copyWith(additionalInfo: info));
+  }
+
+  void setStartTime(DateTime start) {
+    emit(state.copyWith(startTime: start));
+  }
+
+  void setEndTime(DateTime end) {
+    emit(state.copyWith(endTime: end));
+  }
+
+  Future<void> createSupplyRun(String userId) async {
+    emit(state.copyWith(isSubmitting: true, isSuccess: false, error: null));
+    final element = SupplyRunElement(
+      id: '',
+      startDateTime: state.startTime,
+      endDateTime: state.endTime,
+      additionalInfo: state.additionalInfo,
+      supplyOrderIds: state.selectedIds.toList(),
+      routeDescription: state.routeDescription,
+      addedByUserId: userId,
+      addedTimestamp: DateTime.now(),
+      closed: false,
+    );
+    try {
+      await _grafikRepository.saveGrafikElement(element);
+      // Optional: mark orders as assigned
+      await Future.wait(state.selectedIds
+          .map((id) => _supplyRepository.updateOrderStatus(id, 'assigned')));
+      emit(state.copyWith(isSubmitting: false, isSuccess: true));
+    } catch (e) {
+      emit(state.copyWith(
+          isSubmitting: false, isSuccess: false, error: e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    return super.close();
+  }
+}

--- a/feature/supplies/cubit/supply_run_planning_state.dart
+++ b/feature/supplies/cubit/supply_run_planning_state.dart
@@ -1,0 +1,57 @@
+class SupplyRunPlanningState {
+  final Set<String> selectedIds;
+  final String routeDescription;
+  final String additionalInfo;
+  final DateTime startTime;
+  final DateTime endTime;
+  final bool isSubmitting;
+  final bool isSuccess;
+  final String? error;
+
+  SupplyRunPlanningState({
+    required this.selectedIds,
+    required this.routeDescription,
+    required this.additionalInfo,
+    required this.startTime,
+    required this.endTime,
+    this.isSubmitting = false,
+    this.isSuccess = false,
+    this.error,
+  });
+
+  factory SupplyRunPlanningState.initial() {
+    final now = DateTime.now();
+    return SupplyRunPlanningState(
+      selectedIds: {},
+      routeDescription: '',
+      additionalInfo: '',
+      startTime: now.add(const Duration(hours: 1)),
+      endTime: now.add(const Duration(hours: 2)),
+      isSubmitting: false,
+      isSuccess: false,
+      error: null,
+    );
+  }
+
+  SupplyRunPlanningState copyWith({
+    Set<String>? selectedIds,
+    String? routeDescription,
+    String? additionalInfo,
+    DateTime? startTime,
+    DateTime? endTime,
+    bool? isSubmitting,
+    bool? isSuccess,
+    String? error,
+  }) {
+    return SupplyRunPlanningState(
+      selectedIds: selectedIds ?? this.selectedIds,
+      routeDescription: routeDescription ?? this.routeDescription,
+      additionalInfo: additionalInfo ?? this.additionalInfo,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      isSuccess: isSuccess ?? this.isSuccess,
+      error: error ?? this.error,
+    );
+  }
+}

--- a/feature/supplies/supply_run_planning_screen.dart
+++ b/feature/supplies/supply_run_planning_screen.dart
@@ -2,16 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 
-import '../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../domain/models/supply_order.dart';
 import '../../data/repositories/grafik_element_repository.dart';
 import '../../domain/services/i_supply_repository.dart';
 import '../auth/auth_cubit.dart';
+import '../supplies/cubit/supply_run_planning_cubit.dart';
+import '../supplies/cubit/supply_run_planning_state.dart';
 import '../../shared/app_drawer.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../../shared/datetime/date_time_picker_field.dart';
 import '../../theme/app_tokens.dart';
-import 'supply_orders_cubit.dart';
-import '../../domain/models/supply_order.dart';
 
 class SupplyRunPlanningScreen extends StatefulWidget {
   const SupplyRunPlanningScreen({super.key});
@@ -23,17 +23,10 @@ class SupplyRunPlanningScreen extends StatefulWidget {
 class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
   final _routeCtrl = TextEditingController();
   final _infoCtrl = TextEditingController();
-  final Set<String> _selected = {};
-  late DateTimeRange _range;
 
   @override
   void initState() {
     super.initState();
-    final now = DateTime.now();
-    _range = DateTimeRange(
-      start: now.add(const Duration(hours: 1)),
-      end: now.add(const Duration(hours: 2)),
-    );
   }
 
   @override
@@ -46,35 +39,16 @@ class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
   Future<void> _planRun() async {
     final user = context.read<AuthCubit>().currentUser;
     if (user == null) return;
-    final repo = GetIt.I<GrafikElementRepository>();
-    final element = SupplyRunElement(
-      id: '',
-      startDateTime: _range.start,
-      endDateTime: _range.end,
-      additionalInfo: _infoCtrl.text,
-      supplyOrderIds: _selected.toList(),
-      routeDescription: _routeCtrl.text,
-      addedByUserId: user.id,
-      addedTimestamp: DateTime.now(),
-      closed: false,
-    );
-    await repo.saveGrafikElement(element);
+    await context.read<SupplyRunPlanningCubit>().createSupplyRun(user.id);
     if (mounted) Navigator.of(context).pop();
   }
 
-  Widget _buildOrderTile(SupplyOrder order) {
-    final checked = _selected.contains(order.id);
+  Widget _buildOrderTile(
+      SupplyOrder order, SupplyRunPlanningState state, SupplyRunPlanningCubit cubit) {
+    final checked = state.selectedIds.contains(order.id);
     return CheckboxListTile(
       value: checked,
-      onChanged: (val) {
-        setState(() {
-          if (val ?? false) {
-            _selected.add(order.id);
-          } else {
-            _selected.remove(order.id);
-          }
-        });
-      },
+      onChanged: (_) => cubit.toggleSelection(order.id),
       title: Text('${order.itemId} x${order.quantityRequested}'),
       dense: true,
     );
@@ -83,69 +57,89 @@ class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => SupplyOrdersCubit(GetIt.I<ISupplyRepository>()),
-      child: ResponsiveScaffold(
-        drawer: const AppDrawer(),
-        appBar: AppBar(
-          title: const Text('Planowanie trasy'),
-        ),
-        body: LayoutBuilder(
-          builder: (context, constraints) {
-            return SingleChildScrollView(
-              child: ResponsivePadding(
-                small: const EdgeInsets.all(16),
-                medium: const EdgeInsets.all(24),
-                large: const EdgeInsets.all(32),
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      StreamBuilder<List<SupplyOrder>>(
-                        stream: context.read<SupplyOrdersCubit>().stream,
-                        builder: (context, snapshot) {
-                          if (!snapshot.hasData) {
-                            return const Center(child: CircularProgressIndicator());
-                          }
-                          final orders = snapshot.data!;
-                          if (orders.isEmpty) {
-                            return const Text('Brak oczekujących zamówień');
-                          }
-                          return Column(
-                            children: orders.map(_buildOrderTile).toList(),
-                          );
-                        },
+      create: (_) => SupplyRunPlanningCubit(
+        GetIt.I<ISupplyRepository>(),
+        GetIt.I<GrafikElementRepository>(),
+      ),
+      child: BlocBuilder<SupplyRunPlanningCubit, SupplyRunPlanningState>(
+        builder: (context, state) {
+          final cubit = context.read<SupplyRunPlanningCubit>();
+          return ResponsiveScaffold(
+            drawer: const AppDrawer(),
+            appBar: AppBar(
+              title: const Text('Planowanie trasy'),
+            ),
+            body: LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  child: ResponsivePadding(
+                    small: const EdgeInsets.all(16),
+                    medium: const EdgeInsets.all(24),
+                    large: const EdgeInsets.all(32),
+                    child: ConstrainedBox(
+                      constraints:
+                          BoxConstraints(minHeight: constraints.maxHeight),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          StreamBuilder<List<SupplyOrder>>(
+                            stream: cubit.streamSupplyOrders(),
+                            builder: (context, snapshot) {
+                              if (!snapshot.hasData) {
+                                return const Center(
+                                    child: CircularProgressIndicator());
+                              }
+                              final orders = snapshot.data!;
+                              if (orders.isEmpty) {
+                                return const Text('Brak oczekujących zamówień');
+                              }
+                              return Column(
+                                children: orders
+                                    .map((o) => _buildOrderTile(o, state, cubit))
+                                    .toList(),
+                              );
+                            },
+                          ),
+                          const SizedBox(height: AppSpacing.lg),
+                          TextField(
+                            controller: _routeCtrl,
+                            onChanged: cubit.setRouteDescription,
+                            decoration:
+                                const InputDecoration(labelText: 'Opis trasy'),
+                          ),
+                          const SizedBox(height: AppSpacing.lg),
+                          TextField(
+                            controller: _infoCtrl,
+                            onChanged: cubit.setAdditionalInfo,
+                            decoration: const InputDecoration(
+                                labelText: 'Dodatkowe informacje'),
+                          ),
+                          const SizedBox(height: AppSpacing.lg),
+                          DateTimePickerField(
+                            initialDate: state.startTime,
+                            initialStartHour: state.startTime.hour.toDouble(),
+                            initialEndHour: state.endTime.hour.toDouble(),
+                            onChanged: (range) {
+                              cubit.setStartTime(range.start);
+                              cubit.setEndTime(range.end);
+                            },
+                          ),
+                          const SizedBox(height: AppSpacing.lg * 2),
+                          ElevatedButton(
+                            onPressed: state.selectedIds.isEmpty
+                                ? null
+                                : _planRun,
+                            child: const Text('Zaplanuj trasę'),
+                          ),
+                        ],
                       ),
-                      const SizedBox(height: AppSpacing.lg),
-                      TextField(
-                        controller: _routeCtrl,
-                        decoration: const InputDecoration(labelText: 'Opis trasy'),
-                      ),
-                      const SizedBox(height: AppSpacing.lg),
-                      TextField(
-                        controller: _infoCtrl,
-                        decoration:
-                            const InputDecoration(labelText: 'Dodatkowe informacje'),
-                      ),
-                      const SizedBox(height: AppSpacing.lg),
-                      DateTimePickerField(
-                        initialDate: _range.start,
-                        initialStartHour: _range.start.hour.toDouble(),
-                        initialEndHour: _range.end.hour.toDouble(),
-                        onChanged: (range) => setState(() => _range = range),
-                      ),
-                      const SizedBox(height: AppSpacing.lg * 2),
-                      ElevatedButton(
-                        onPressed: _selected.isEmpty ? null : _planRun,
-                        child: const Text('Zaplanuj trasę'),
-                      ),
-                    ],
+                    ),
                   ),
-                ),
-              ),
-            );
-          },
-        ),
+                );
+              },
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add `SupplyRunPlanningCubit` and state for planning supply runs
- update Firestore repository to support order status updates
- expose `updateOrderStatus` in the supply repository interface
- refactor supply run planning screen to use the new cubit

## Testing
- `flutter` and `dart` were unavailable so analysis could not be run

------
https://chatgpt.com/codex/tasks/task_e_6877e5edea008333ab2e9dfe1eb13ef1