### PR TITLE
Add SupplyRunPlanningState with available orders

### DIFF
--- a/feature/supplies/cubit/supply_run_planning_cubit.dart
+++ b/feature/supplies/cubit/supply_run_planning_cubit.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../domain/models/grafik/impl/supply_run_element.dart';
@@ -9,25 +10,25 @@ import 'supply_run_planning_state.dart';
 class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
   final ISupplyRepository _supplyRepository;
   final GrafikElementRepository _grafikRepository;
+  late final StreamSubscription<List<SupplyOrder>> _ordersSub;
   SupplyRunPlanningCubit(
     this._supplyRepository,
     this._grafikRepository,
-  ) : super(SupplyRunPlanningState.initial());
-
-  Stream<List<SupplyOrder>> streamSupplyOrders() {
-    return _supplyRepository
-        .watchOrders()
-        .map((orders) => orders.where((o) => o.status == 'pending').toList());
+  ) : super(SupplyRunPlanningState.initial()) {
+    _ordersSub = _supplyRepository.watchOrders().listen((orders) {
+      final pending = orders.where((o) => o.status == 'pending').toList();
+      emit(state.copyWith(availableOrders: pending));
+    });
   }
 
   void toggleSelection(String orderId) {
-    final newSet = Set<String>.from(state.selectedIds);
+    final newSet = Set<String>.from(state.selectedOrderIds);
     if (newSet.contains(orderId)) {
       newSet.remove(orderId);
     } else {
       newSet.add(orderId);
     }
-    emit(state.copyWith(selectedIds: newSet));
+    emit(state.copyWith(selectedOrderIds: newSet));
   }
 
   void setRouteDescription(String desc) {
@@ -38,22 +39,22 @@ class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
     emit(state.copyWith(additionalInfo: info));
   }
 
-  void setStartTime(DateTime start) {
-    emit(state.copyWith(startTime: start));
+  void setStartDateTime(DateTime start) {
+    emit(state.copyWith(startDateTime: start));
   }
 
-  void setEndTime(DateTime end) {
-    emit(state.copyWith(endTime: end));
+  void setEndDateTime(DateTime end) {
+    emit(state.copyWith(endDateTime: end));
   }
 
   Future<void> createSupplyRun(String userId) async {
-    emit(state.copyWith(isSubmitting: true, isSuccess: false, error: null));
+    emit(state.copyWith(isSubmitting: true, success: false, errorMsg: null));
     final element = SupplyRunElement(
       id: '',
-      startDateTime: state.startTime,
-      endDateTime: state.endTime,
+      startDateTime: state.startDateTime,
+      endDateTime: state.endDateTime,
       additionalInfo: state.additionalInfo,
-      supplyOrderIds: state.selectedIds.toList(),
+      supplyOrderIds: state.selectedOrderIds.toList(),
       routeDescription: state.routeDescription,
       addedByUserId: userId,
       addedTimestamp: DateTime.now(),
@@ -62,17 +63,18 @@ class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
     try {
       await _grafikRepository.saveGrafikElement(element);
       // Optional: mark orders as assigned
-      await Future.wait(state.selectedIds
+      await Future.wait(state.selectedOrderIds
           .map((id) => _supplyRepository.updateOrderStatus(id, 'assigned')));
-      emit(state.copyWith(isSubmitting: false, isSuccess: true));
+      emit(state.copyWith(isSubmitting: false, success: true));
     } catch (e) {
       emit(state.copyWith(
-          isSubmitting: false, isSuccess: false, error: e.toString()));
+          isSubmitting: false, success: false, errorMsg: e.toString()));
     }
   }
 
   @override
   Future<void> close() {
+    _ordersSub.cancel();
     return super.close();
   }
 }

--- a/feature/supplies/cubit/supply_run_planning_state.dart
+++ b/feature/supplies/cubit/supply_run_planning_state.dart
@@ -1,57 +1,64 @@
+import '../../../domain/models/supply_order.dart';
+
 class SupplyRunPlanningState {
-  final Set<String> selectedIds;
+  final List<SupplyOrder> availableOrders;
+  final Set<String> selectedOrderIds;
   final String routeDescription;
   final String additionalInfo;
-  final DateTime startTime;
-  final DateTime endTime;
+  final DateTime startDateTime;
+  final DateTime endDateTime;
   final bool isSubmitting;
-  final bool isSuccess;
-  final String? error;
+  final bool success;
+  final String? errorMsg;
 
   SupplyRunPlanningState({
-    required this.selectedIds,
+    required this.availableOrders,
+    required this.selectedOrderIds,
     required this.routeDescription,
     required this.additionalInfo,
-    required this.startTime,
-    required this.endTime,
+    required this.startDateTime,
+    required this.endDateTime,
     this.isSubmitting = false,
-    this.isSuccess = false,
-    this.error,
+    this.success = false,
+    this.errorMsg,
   });
 
   factory SupplyRunPlanningState.initial() {
     final now = DateTime.now();
     return SupplyRunPlanningState(
-      selectedIds: {},
+      availableOrders: const [],
+      selectedOrderIds: {},
       routeDescription: '',
       additionalInfo: '',
-      startTime: now.add(const Duration(hours: 1)),
-      endTime: now.add(const Duration(hours: 2)),
+      startDateTime: now.add(const Duration(hours: 1)),
+      endDateTime: now.add(const Duration(hours: 2)),
       isSubmitting: false,
-      isSuccess: false,
-      error: null,
+      success: false,
+      errorMsg: null,
     );
   }
 
   SupplyRunPlanningState copyWith({
-    Set<String>? selectedIds,
+    List<SupplyOrder>? availableOrders,
+    Set<String>? selectedOrderIds,
     String? routeDescription,
     String? additionalInfo,
-    DateTime? startTime,
-    DateTime? endTime,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
     bool? isSubmitting,
-    bool? isSuccess,
-    String? error,
+    bool? success,
+    String? errorMsg,
   }) {
     return SupplyRunPlanningState(
-      selectedIds: selectedIds ?? this.selectedIds,
+      availableOrders: availableOrders ?? this.availableOrders,
+      selectedOrderIds: selectedOrderIds ?? this.selectedOrderIds,
       routeDescription: routeDescription ?? this.routeDescription,
       additionalInfo: additionalInfo ?? this.additionalInfo,
-      startTime: startTime ?? this.startTime,
-      endTime: endTime ?? this.endTime,
+      startDateTime: startDateTime ?? this.startDateTime,
+      endDateTime: endDateTime ?? this.endDateTime,
       isSubmitting: isSubmitting ?? this.isSubmitting,
-      isSuccess: isSuccess ?? this.isSuccess,
-      error: error ?? this.error,
+      success: success ?? this.success,
+      errorMsg: errorMsg ?? this.errorMsg,
     );
   }
 }

--- a/feature/supplies/supply_run_planning_screen.dart
+++ b/feature/supplies/supply_run_planning_screen.dart
@@ -45,7 +45,7 @@ class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
 
   Widget _buildOrderTile(
       SupplyOrder order, SupplyRunPlanningState state, SupplyRunPlanningCubit cubit) {
-    final checked = state.selectedIds.contains(order.id);
+    final checked = state.selectedOrderIds.contains(order.id);
     return CheckboxListTile(
       value: checked,
       onChanged: (_) => cubit.toggleSelection(order.id),
@@ -82,24 +82,14 @@ class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          StreamBuilder<List<SupplyOrder>>(
-                            stream: cubit.streamSupplyOrders(),
-                            builder: (context, snapshot) {
-                              if (!snapshot.hasData) {
-                                return const Center(
-                                    child: CircularProgressIndicator());
-                              }
-                              final orders = snapshot.data!;
-                              if (orders.isEmpty) {
-                                return const Text('Brak oczekujących zamówień');
-                              }
-                              return Column(
-                                children: orders
-                                    .map((o) => _buildOrderTile(o, state, cubit))
-                                    .toList(),
-                              );
-                            },
-                          ),
+                          if (state.availableOrders.isEmpty)
+                            const Text('Brak oczekujących zamówień')
+                          else
+                            Column(
+                              children: state.availableOrders
+                                  .map((o) => _buildOrderTile(o, state, cubit))
+                                  .toList(),
+                            ),
                           const SizedBox(height: AppSpacing.lg),
                           TextField(
                             controller: _routeCtrl,
@@ -116,17 +106,18 @@ class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
                           ),
                           const SizedBox(height: AppSpacing.lg),
                           DateTimePickerField(
-                            initialDate: state.startTime,
-                            initialStartHour: state.startTime.hour.toDouble(),
-                            initialEndHour: state.endTime.hour.toDouble(),
+                            initialDate: state.startDateTime,
+                            initialStartHour:
+                                state.startDateTime.hour.toDouble(),
+                            initialEndHour: state.endDateTime.hour.toDouble(),
                             onChanged: (range) {
-                              cubit.setStartTime(range.start);
-                              cubit.setEndTime(range.end);
+                              cubit.setStartDateTime(range.start);
+                              cubit.setEndDateTime(range.end);
                             },
                           ),
                           const SizedBox(height: AppSpacing.lg * 2),
                           ElevatedButton(
-                            onPressed: state.selectedIds.isEmpty
+                            onPressed: state.selectedOrderIds.isEmpty
                                 ? null
                                 : _planRun,
                             child: const Text('Zaplanuj trasę'),


### PR DESCRIPTION
## Summary
- add supply order list to SupplyRunPlanningState
- track orders in SupplyRunPlanningCubit
- update planning screen to read orders from state
- rename fields for clarity

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877ec67c78c833393327f03d40147e5