### PR TITLE
Support new element type in grafik load

### DIFF
--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -84,7 +84,11 @@ class GrafikCubit extends Cubit<GrafikState> {
       _grafikRepo.getElementsWithinRange(
         start: start,
         end: end,
-        types: ['TaskElement', 'TimeIssueElement'],
+        types: [
+          'TaskElement',
+          'TimeIssueElement',
+          'SupplyRunElement',
+        ],
       ),
       _employeeRepo.getEmployees(),
       _taskAssignmentRepo.getAssignmentsWithinRange(start: start, end: end),
@@ -141,6 +145,7 @@ class GrafikCubit extends Cubit<GrafikState> {
         'TimeIssueElement',
         'TaskPlanningElement',
         'DeliveryPlanningElement',
+        'SupplyRunElement',
       ],
     );
 


### PR DESCRIPTION
## Summary
- include `SupplyRunElement` when loading grafik data for day/week views

## Testing
- `dart`/`flutter` not available, so no tests run

------
https://chatgpt.com/codex/tasks/task_e_68780801092883338912c2e45b33c113