### PR TITLE
Add Zaopatrzenie task type

### DIFF
--- a/data/dto/grafik/task_element_dto.dart
+++ b/data/dto/grafik/task_element_dto.dart
@@ -46,11 +46,11 @@ class TaskElementDto extends GrafikElementDto {
       closed: json['closed'] as bool? ?? false,
       orderId: json['orderId'] as String? ?? '',
       status: GrafikStatus.values.firstWhere(
-        (e) => e.toString() == (json['status'] ?? 'GrafikStatus.Realizacja'),
+        (e) => e.name == (json['status'] ?? 'Realizacja'),
         orElse: () => GrafikStatus.Realizacja,
       ),
       taskType: GrafikTaskType.values.firstWhere(
-        (e) => e.toString() == (json['taskType'] ?? 'GrafikTaskType.Inne'),
+        (e) => e.name == (json['taskType'] ?? 'Inne'),
         orElse: () => GrafikTaskType.Inne,
       ),
       carIds: (json['carIds'] as List?)?.cast<String>() ?? <String>[],
@@ -60,8 +60,8 @@ class TaskElementDto extends GrafikElementDto {
   Map<String, dynamic> toJson() => {
         ...baseToJson(),
         'orderId': orderId,
-        'status': status.toString(),
-        'taskType': taskType.toString(),
+        'status': status.name,
+        'taskType': taskType.name,
         'carIds': carIds,
       };
 

--- a/data/dto/grafik/task_planning_element_dto.dart
+++ b/data/dto/grafik/task_planning_element_dto.dart
@@ -55,12 +55,11 @@ class TaskPlanningElementDto extends GrafikElementDto {
       workerCount: json['workerCount'] as int? ?? 1,
       orderId: json['orderId'] as String? ?? '',
       probability: GrafikProbability.values.firstWhere(
-        (e) => e.toString() ==
-            (json['probability'] ?? 'GrafikProbability.Pewne'),
+        (e) => e.name == (json['probability'] ?? 'Pewne'),
         orElse: () => GrafikProbability.Pewne,
       ),
       taskType: GrafikTaskType.values.firstWhere(
-        (e) => e.toString() == (json['taskType'] ?? 'GrafikTaskType.Inne'),
+        (e) => e.name == (json['taskType'] ?? 'Inne'),
         orElse: () => GrafikTaskType.Inne,
       ),
       minutes: json['minutes'] as int? ?? 60,
@@ -75,8 +74,8 @@ class TaskPlanningElementDto extends GrafikElementDto {
         ...baseToJson(),
         'workerCount': workerCount,
         'orderId': orderId,
-        'probability': probability.toString(),
-        'taskType': taskType.toString(),
+        'probability': probability.name,
+        'taskType': taskType.name,
         'minutes': minutes,
         'highPriority': highPriority,
         'isPending': isPending,

--- a/domain/models/grafik/enums.dart
+++ b/domain/models/grafik/enums.dart
@@ -10,6 +10,7 @@ enum GrafikTaskType {
   Produkcja,
   Budowa,
   Inne,
+  Zaopatrzenie,
 }
 
 enum GrafikProbability {

--- a/feature/grafik/constants/enums_ui.dart
+++ b/feature/grafik/constants/enums_ui.dart
@@ -27,6 +27,8 @@ extension GrafikTaskTypeX on GrafikTaskType {
         return Icons.handyman;
       case GrafikTaskType.Inne:
         return Icons.more_horiz;
+      case GrafikTaskType.Zaopatrzenie:
+        return Icons.local_shipping;
     }
   }
 
@@ -41,6 +43,8 @@ extension GrafikTaskTypeX on GrafikTaskType {
         return Colors.green;
       case GrafikTaskType.Inne:
         return Colors.grey;
+      case GrafikTaskType.Zaopatrzenie:
+        return Colors.brown;
     }
   }
 }

--- a/feature/grafik/widget/task/task_list.dart
+++ b/feature/grafik/widget/task/task_list.dart
@@ -45,17 +45,19 @@ class TaskList extends StatelessWidget {
         }
         // Sort tasks by custom rules
         int typeIndex(GrafikTaskType t) {
-          switch (t) {
-            case GrafikTaskType.Produkcja:
-              return 0;
-            case GrafikTaskType.Inne:
-              return 1;
-            case GrafikTaskType.Budowa:
-              return 2;
-            case GrafikTaskType.Serwis:
-              return 3;
+            switch (t) {
+              case GrafikTaskType.Produkcja:
+                return 0;
+              case GrafikTaskType.Inne:
+                return 1;
+              case GrafikTaskType.Budowa:
+                return 2;
+              case GrafikTaskType.Serwis:
+                return 3;
+              case GrafikTaskType.Zaopatrzenie:
+                return 4;
+            }
           }
-        }
 
         tasks.sort((a, b) {
           final type = typeIndex(a.taskType).compareTo(typeIndex(b.taskType));


### PR DESCRIPTION
## Summary
- extend `GrafikTaskType` with `Zaopatrzenie`
- show icon and border color for new task type
- sort tasks by the new type in `TaskList`
- map enums by name in DTOs

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687917d402648333b346fdb56a4c6cca