### PR TITLE
Track user supply runs in Grafik

### DIFF
--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -13,8 +13,10 @@ import '../../../domain/models/grafik/grafik_element.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
+import '../../../domain/models/grafik/impl/supply_run_element.dart';
 import '../../../domain/models/vehicle.dart';
 import '../../../domain/models/grafik/task_assignment.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'grafik_mapping_utils.dart';
 import 'grafik_state.dart';
 
@@ -95,6 +97,11 @@ class GrafikCubit extends Cubit<GrafikState> {
           (elements, employees, assignments) {
         final tasks = elements.whereType<TaskElement>().toList();
         final issues = elements.whereType<TimeIssueElement>().toList();
+        final supplyRuns = elements
+            .whereType<SupplyRunElement>()
+            .where((r) => r.addedByUserId ==
+                FirebaseAuth.instance.currentUser?.uid)
+            .toList();
 
         final mapping = calculateTaskTimeIssueDisplayMapping(
           tasks: tasks,
@@ -112,6 +119,7 @@ class GrafikCubit extends Cubit<GrafikState> {
         return {
           'tasks': tasks,
           'issues': issues,
+          'supplyRuns': supplyRuns,
           'employees': employees,
           'assignments': assignments,
           'mapping': mapping,
@@ -123,6 +131,7 @@ class GrafikCubit extends Cubit<GrafikState> {
         emit(state.copyWith(
           tasks: combinedData['tasks'] as List<TaskElement>,
           issues: combinedData['issues'] as List<TimeIssueElement>,
+          supplyRuns: combinedData['supplyRuns'] as List<SupplyRunElement>,
           employees: combinedData['employees'] as List<Employee>,
           taskTimeIssueDisplayMapping:
               combinedData['mapping'] as Map<String, List<String>>,
@@ -162,12 +171,18 @@ class GrafikCubit extends Cubit<GrafikState> {
         final timeIssues = elements.whereType<TimeIssueElement>().toList();
         final taskPlannings = elements.whereType<TaskPlanningElement>().toList();
         final deliveryPlannings = elements.whereType<DeliveryPlanningElement>().toList();
+        final supplyRuns = elements
+            .whereType<SupplyRunElement>()
+            .where((r) =>
+                r.addedByUserId == FirebaseAuth.instance.currentUser?.uid)
+            .toList();
 
         return {
           'taskElements': taskElements,
           'timeIssues': timeIssues,
           'taskPlannings': taskPlannings,
           'deliveryPlanningElements': deliveryPlannings,
+          'supplyRuns': supplyRuns,
           'employees': employees,
         };
       },
@@ -178,6 +193,7 @@ class GrafikCubit extends Cubit<GrafikState> {
         taskPlannings: data['taskPlannings'] as List<TaskPlanningElement>,
         deliveryPlannings:
             data['deliveryPlanningElements'] as List<DeliveryPlanningElement>,
+        supplyRuns: data['supplyRuns'] as List<SupplyRunElement>,
       );
       emit(state.copyWith(
         weekData: updatedWeek,

--- a/feature/grafik/cubit/grafik_state.dart
+++ b/feature/grafik/cubit/grafik_state.dart
@@ -1,5 +1,6 @@
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
+import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
 import 'package:kabast/domain/models/vehicle.dart';
 import 'package:kabast/domain/models/employee.dart';
 import 'package:kabast/domain/models/grafik/task_assignment.dart';
@@ -8,6 +9,7 @@ import 'states/week_grafik_data.dart';
 class GrafikState {
   final List<TaskElement> tasks;
   final List<TimeIssueElement> issues;
+  final List<SupplyRunElement> supplyRuns;
   final List<TaskAssignment> assignments;
   final Map<String, List<String>> taskTimeIssueDisplayMapping;
   final Map<String, List<String>> taskTransferDisplayMapping;
@@ -20,6 +22,7 @@ class GrafikState {
   GrafikState({
     required this.tasks,
     required this.issues,
+    required this.supplyRuns,
     required this.taskTimeIssueDisplayMapping,
     required this.taskTransferDisplayMapping,
     required this.assignments,
@@ -33,6 +36,7 @@ class GrafikState {
     return GrafikState(
       tasks: [],
       issues: [],
+      supplyRuns: [],
       taskTimeIssueDisplayMapping: {},
       taskTransferDisplayMapping: {},
       assignments: [],
@@ -46,6 +50,7 @@ class GrafikState {
   GrafikState copyWith({
     List<TaskElement>? tasks,
     List<TimeIssueElement>? issues,
+    List<SupplyRunElement>? supplyRuns,
     Map<String, List<String>>? taskTimeIssueDisplayMapping,
     Map<String, List<String>>? taskTransferDisplayMapping,
     List<TaskAssignment>? assignments,
@@ -57,6 +62,7 @@ class GrafikState {
     return GrafikState(
       tasks: tasks ?? this.tasks,
       issues: issues ?? this.issues,
+      supplyRuns: supplyRuns ?? this.supplyRuns,
       taskTimeIssueDisplayMapping: taskTimeIssueDisplayMapping ?? this.taskTimeIssueDisplayMapping,
       taskTransferDisplayMapping: taskTransferDisplayMapping ?? this.taskTransferDisplayMapping,
       assignments: assignments ?? this.assignments,

--- a/feature/grafik/cubit/states/week_grafik_data.dart
+++ b/feature/grafik/cubit/states/week_grafik_data.dart
@@ -2,18 +2,21 @@ import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart'
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
+import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
 
 class WeekGrafikData {
   final List<TaskElement> taskElements;
   final List<TimeIssueElement> timeIssues;
   final List<TaskPlanningElement> taskPlannings;
   final List<DeliveryPlanningElement> deliveryPlannings;
+  final List<SupplyRunElement> supplyRuns;
 
   WeekGrafikData({
     required this.taskElements,
     required this.timeIssues,
     required this.taskPlannings,
     required this.deliveryPlannings,
+    required this.supplyRuns,
   });
 
   factory WeekGrafikData.initial() => WeekGrafikData(
@@ -21,6 +24,7 @@ class WeekGrafikData {
         timeIssues: [],
         taskPlannings: [],
         deliveryPlannings: [],
+        supplyRuns: [],
       );
 
   WeekGrafikData copyWith({
@@ -28,12 +32,14 @@ class WeekGrafikData {
     List<TimeIssueElement>? timeIssues,
     List<TaskPlanningElement>? taskPlannings,
     List<DeliveryPlanningElement>? deliveryPlannings,
+    List<SupplyRunElement>? supplyRuns,
   }) {
     return WeekGrafikData(
       taskElements: taskElements ?? this.taskElements,
       timeIssues: timeIssues ?? this.timeIssues,
       taskPlannings: taskPlannings ?? this.taskPlannings,
       deliveryPlannings: deliveryPlannings ?? this.deliveryPlannings,
+      supplyRuns: supplyRuns ?? this.supplyRuns,
     );
   }
 }

--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -72,6 +72,7 @@ class ForegroundLayer extends StatelessWidget {
         final planningElements = <GrafikElement>[
           ...state.weekData.taskPlannings,
           ...state.weekData.deliveryPlannings,
+          ...state.weekData.supplyRuns,
           ...state.weekData.taskElements,
           ...state.weekData.timeIssues,
         ];


### PR DESCRIPTION
## Summary
- extend `WeekGrafikData` and `GrafikState` with `supplyRuns`
- watch supply run elements in `GrafikCubit`
- filter runs by current user
- include supply runs in week view rendering

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879345555f883339f971aebd008f582