### PR TITLE
Add supply run week tiles and list

### DIFF
--- a/feature/grafik/widget/single_day_grafik_view.dart
+++ b/feature/grafik/widget/single_day_grafik_view.dart
@@ -5,6 +5,7 @@ import 'package:kabast/shared/responsive/responsive_layout.dart';
 import 'package:kabast/theme/app_tokens.dart';
 import 'package:kabast/theme/theme.dart';
 import 'package:kabast/feature/grafik/widget/task/task_list.dart';
+import 'package:kabast/feature/grafik/widget/task/supply_run_list.dart';
 import 'package:kabast/feature/date/date_cubit.dart';
 
 import '../../../shared/appbar/grafik_appbar.dart';
@@ -129,10 +130,23 @@ class _SingleDayGrafikViewState extends State<SingleDayGrafikView> {
             small: const EdgeInsets.all(AppSpacing.sm),
             medium: const EdgeInsets.all(AppSpacing.sm * 2),
             large: const EdgeInsets.all(AppSpacing.sm * 3),
-          child: TaskList(
-            date: selectedDay,
-            breakpoint: bp,
-            showAll: _showAll,
+          child: Column(
+            children: [
+              Expanded(
+                child: TaskList(
+                  date: selectedDay,
+                  breakpoint: bp,
+                  showAll: _showAll,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm * 2),
+              Expanded(
+                child: SupplyRunList(
+                  breakpoint: bp,
+                  showAll: _showAll,
+                ),
+              ),
+            ],
           ),
       ),
           floatingActionButton: const AddGrafikFAB(),

--- a/feature/grafik/widget/task/supply_run_list.dart
+++ b/feature/grafik/widget/task/supply_run_list.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
+import 'package:kabast/shared/utils/tile_size_resolver.dart';
+import 'package:kabast/shared/responsive/responsive_layout.dart';
+import 'package:kabast/theme/app_tokens.dart';
+import 'package:kabast/theme/theme.dart';
+
+import '../../../auth/auth_cubit.dart';
+import '../../cubit/grafik_cubit.dart';
+import '../../cubit/grafik_state.dart';
+
+class SupplyRunList extends StatelessWidget {
+  final Breakpoint breakpoint;
+  final bool showAll;
+
+  const SupplyRunList({
+    Key? key,
+    required this.breakpoint,
+    required this.showAll,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<GrafikCubit, GrafikState>(
+      builder: (context, state) {
+        List<SupplyRunElement> runs = List.from(state.supplyRuns);
+        if (!showAll) {
+          final userId = context.read<AuthCubit>().currentUser?.employeeId;
+          runs = runs.where((r) => r.addedByUserId == userId).toList();
+        }
+
+        runs.sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
+
+        if (runs.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        final columns = switch (breakpoint) {
+          Breakpoint.small => 1,
+          Breakpoint.medium => 2,
+          Breakpoint.large => 2,
+        };
+
+        return LayoutBuilder(
+          builder: (context, gridConstraints) {
+            final runCount = runs.length;
+            final rows = (runCount / columns).ceil();
+
+            final totalSpacingHeight =
+                AppSpacing.sm * (rows > 0 ? rows - 1 : 0);
+            final availableHeight =
+                gridConstraints.maxHeight - totalSpacingHeight;
+            final tileHeight =
+                rows > 0 ? availableHeight / rows : gridConstraints.maxHeight;
+
+            final tileWidth =
+                (gridConstraints.maxWidth - AppSpacing.sm * (columns - 1)) /
+                    columns;
+            final aspectRatio = tileWidth / tileHeight;
+
+            return GridView.builder(
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: columns,
+                crossAxisSpacing: AppSpacing.sm,
+                mainAxisSpacing: AppSpacing.sm,
+                childAspectRatio: aspectRatio,
+              ),
+              itemCount: runs.length,
+              itemBuilder: (context, index) {
+                final run = runs[index];
+                const data = GrafikElementData(
+                  assignedEmployees: [],
+                  assignedVehicles: [],
+                );
+                return LayoutBuilder(
+                  builder: (context, constraints) {
+                    final variant = TileSizeResolver.resolve(
+                      width: constraints.maxWidth,
+                    );
+                    return GrafikElementCard(
+                      element: run,
+                      data: data,
+                      variant: variant,
+                    );
+                  },
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -5,12 +5,14 @@ import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
+import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
 import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/default_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/task_planning_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/task_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/time_issue_week_tile.dart';
+import 'package:kabast/feature/grafik/widget/week/tiles/supply_run_week_tile.dart';
 
 import '../../cubit/grafik_cubit.dart';
 import '../../cubit/grafik_state.dart';
@@ -64,6 +66,13 @@ class ForegroundLayer extends StatelessWidget {
     );
   }
 
+  GrafikElementData _supplyRunData(GrafikState state) {
+    return const GrafikElementData(
+      assignedEmployees: [],
+      assignedVehicles: [],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<GrafikCubit, GrafikState>(
@@ -94,6 +103,11 @@ class ForegroundLayer extends StatelessWidget {
               return DeliveryPlanningWeekTile(
                 deliveryPlanning: elem,
                 data: _deliveryPlanningData(state),
+              );
+            } else if (elem is SupplyRunElement) {
+              return SupplyRunWeekTile(
+                supplyRun: elem,
+                data: _supplyRunData(state),
               );
             } else if (elem is TaskElement) {
               return TaskWeekTile(

--- a/feature/grafik/widget/week/tiles/supply_run_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/supply_run_week_tile.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
+import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_delegate.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_variant.dart';
+
+import '../../../../../theme/size_variants.dart';
+
+class SupplyRunWeekTile extends StatelessWidget {
+  final SupplyRunElement supplyRun;
+  final GrafikElementData data;
+
+  const SupplyRunWeekTile({
+    Key? key,
+    required this.supplyRun,
+    required this.data,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
+        return TurboGrid(
+          tiles: [
+            TurboTile(
+              priority: 1,
+              required: true,
+              delegate: _SupplyRunCardDelegate(supplyRun, data, width, height),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _SupplyRunCardDelegate extends TurboTileDelegate {
+  final SupplyRunElement supplyRun;
+  final GrafikElementData data;
+  final double width;
+  final double height;
+
+  _SupplyRunCardDelegate(this.supplyRun, this.data, this.width, this.height);
+
+  @override
+  List<TurboTileVariant> createVariants() => [
+        _variant(SizeVariant.large),
+        _variant(SizeVariant.medium),
+        _variant(SizeVariant.small),
+        _variant(SizeVariant.mini),
+      ];
+
+  TurboTileVariant _variant(SizeVariant v) {
+    return TurboTileVariant(
+      size: Size(width, height),
+      builder: (context, constraints) => SizedBox.expand(
+        child: GrafikElementCard(
+          element: supplyRun,
+          data: data,
+          variant: v,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show SupplyRunElements in weekly grafik grid using `SupplyRunWeekTile`
- add `SupplyRunList` widget to render daily supply runs
- display supply runs in single day view

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879362b1dac833396868718d93d2ea9