### PR TITLE
Add FAB for planning supply runs

### DIFF
--- a/domain/models/app_user.dart
+++ b/domain/models/app_user.dart
@@ -23,6 +23,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': true,
         'canSeeAllGrafik': true,
         'canApprove': true,
+        'canPlanSupplyRun': true,
         'canUseApp': true,
       };
     case UserRole.czlowiekZarzadu:
@@ -38,6 +39,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': true,
         'canSeeAllGrafik': true,
         'canApprove': false,
+        'canPlanSupplyRun': false,
         'canUseApp': true,
       };
     case UserRole.kierownik:
@@ -52,6 +54,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': true,
         'canSeeAllGrafik': true,
         'canApprove': true,
+        'canPlanSupplyRun': true,
         'canUseApp': true,
       };
     case UserRole.monter:
@@ -66,6 +69,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': false,
         'canSeeAllGrafik': false,
         'canApprove': false,
+        'canPlanSupplyRun': false,
         'canUseApp': true,
       };
     case UserRole.hala:
@@ -80,6 +84,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': true,
         'canSeeAllGrafik': false,
         'canApprove': false,
+        'canPlanSupplyRun': false,
         'canUseApp': true,
       };
     case UserRole.kierownikProdukcji:
@@ -94,6 +99,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': true,
         'canSeeAllGrafik': true,
         'canApprove': true,
+        'canPlanSupplyRun': true,
         'canUseApp': true,
       };
     default:
@@ -108,6 +114,7 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canChangeDate': false,
         'canSeeAllGrafik': false,
         'canApprove': false,
+        'canPlanSupplyRun': false,
         'canUseApp': false, // tylko user nie może
       };
   }

--- a/feature/supplies/plan_supply_run_fab.dart
+++ b/feature/supplies/plan_supply_run_fab.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import '../permission/permission_widget.dart';
+import '../../shared/custom_fab.dart';
+
+class PlanSupplyRunFAB extends StatelessWidget {
+  const PlanSupplyRunFAB({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return PermissionWidget(
+      permission: 'canPlanSupplyRun',
+      child: CustomFAB(
+        icon: Icons.local_shipping,
+        onPressed: () => Navigator.pushNamed(context, '/planSupplyRun'),
+      ),
+    );
+  }
+}

--- a/feature/supplies/supply_list_screen.dart
+++ b/feature/supplies/supply_list_screen.dart
@@ -5,8 +5,8 @@ import '../../domain/models/supply_item.dart';
 import '../../domain/services/i_supply_repository.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../../shared/app_drawer.dart';
-import '../../shared/custom_fab.dart';
 import '../permission/permission_widget.dart';
+import 'plan_supply_run_fab.dart';
 import 'supply_order_form.dart';
 
 class SupplyListScreen extends StatelessWidget {
@@ -30,9 +30,7 @@ class SupplyListScreen extends StatelessWidget {
           ),
         ],
       ),
-      floatingActionButton: CustomFAB(
-        onPressed: () => Navigator.pushNamed(context, '/planSupplyRun'),
-      ),
+      floatingActionButton: const PlanSupplyRunFAB(),
       body: StreamBuilder<List<SupplyItem>>(
         stream: repo.watchItems(),
         builder: (context, snapshot) {


### PR DESCRIPTION
## Summary
- introduce `PlanSupplyRunFAB` wrapped in `PermissionWidget`
- show the new button on `SupplyListScreen`
- add default `canPlanSupplyRun` permission in `AppUser` roles

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdcabd6548333abb1f4a725f67218