### PR TITLE
Add driver & vehicle selection for supply runs

### DIFF
--- a/data/dto/grafik/supply_run_element_dto.dart
+++ b/data/dto/grafik/supply_run_element_dto.dart
@@ -6,6 +6,8 @@ import 'grafik_element_dto.dart';
 class SupplyRunElementDto extends GrafikElementDto {
   final List<String> supplyOrderIds;
   final String routeDescription;
+  final List<String> vehicleIds;
+  final List<String> driverIds;
 
   SupplyRunElementDto({
     required super.id,
@@ -18,6 +20,8 @@ class SupplyRunElementDto extends GrafikElementDto {
     required super.closed,
     required this.supplyOrderIds,
     required this.routeDescription,
+    this.vehicleIds = const [],
+    this.driverIds = const [],
   });
 
   factory SupplyRunElementDto.fromJson(Map<String, dynamic> json) {
@@ -42,6 +46,8 @@ class SupplyRunElementDto extends GrafikElementDto {
       supplyOrderIds:
           (json['supplyOrderIds'] as List?)?.cast<String>() ?? const <String>[],
       routeDescription: json['routeDescription'] as String? ?? '',
+      vehicleIds: (json['vehicleIds'] as List?)?.cast<String>() ?? const <String>[],
+      driverIds: (json['driverIds'] as List?)?.cast<String>() ?? const <String>[],
     );
   }
 
@@ -50,6 +56,8 @@ class SupplyRunElementDto extends GrafikElementDto {
         ...baseToJson(),
         'supplyOrderIds': supplyOrderIds,
         'routeDescription': routeDescription,
+        'vehicleIds': vehicleIds,
+        'driverIds': driverIds,
       };
 
   @override
@@ -60,6 +68,8 @@ class SupplyRunElementDto extends GrafikElementDto {
         additionalInfo: additionalInfo,
         supplyOrderIds: supplyOrderIds,
         routeDescription: routeDescription,
+        vehicleIds: vehicleIds,
+        driverIds: driverIds,
         addedByUserId: addedByUserId,
         addedTimestamp: addedTimestamp,
         closed: closed,
@@ -77,5 +87,7 @@ class SupplyRunElementDto extends GrafikElementDto {
         closed: element.closed,
         supplyOrderIds: List<String>.from(element.supplyOrderIds),
         routeDescription: element.routeDescription,
+        vehicleIds: List<String>.from(element.vehicleIds),
+        driverIds: List<String>.from(element.driverIds),
       );
 }

--- a/domain/models/grafik/impl/supply_run_element.dart
+++ b/domain/models/grafik/impl/supply_run_element.dart
@@ -4,6 +4,8 @@ import '../grafik_element.dart';
 class SupplyRunElement extends GrafikElement {
   final List<String> supplyOrderIds;
   final String routeDescription;
+  final List<String> vehicleIds;
+  final List<String> driverIds;
 
   SupplyRunElement({
     required String id,
@@ -12,6 +14,8 @@ class SupplyRunElement extends GrafikElement {
     required String additionalInfo,
     required this.supplyOrderIds,
     required this.routeDescription,
+    this.vehicleIds = const [],
+    this.driverIds = const [],
     required String addedByUserId,
     required DateTime addedTimestamp,
     bool closed = false,
@@ -33,6 +37,8 @@ class SupplyRunElement extends GrafikElement {
     String? additionalInfo,
     List<String>? supplyOrderIds,
     String? routeDescription,
+    List<String>? vehicleIds,
+    List<String>? driverIds,
     String? addedByUserId,
     DateTime? addedTimestamp,
     bool? closed,
@@ -44,6 +50,8 @@ class SupplyRunElement extends GrafikElement {
       additionalInfo: additionalInfo ?? this.additionalInfo,
       supplyOrderIds: supplyOrderIds ?? List<String>.from(this.supplyOrderIds),
       routeDescription: routeDescription ?? this.routeDescription,
+      vehicleIds: vehicleIds ?? List<String>.from(this.vehicleIds),
+      driverIds: driverIds ?? List<String>.from(this.driverIds),
       addedByUserId: addedByUserId ?? this.addedByUserId,
       addedTimestamp: addedTimestamp ?? this.addedTimestamp,
       closed: closed ?? this.closed,
@@ -57,6 +65,8 @@ class SupplyRunElement extends GrafikElement {
         additionalInfo: additionalInfo,
         supplyOrderIds: List<String>.from(supplyOrderIds),
         routeDescription: routeDescription,
+        vehicleIds: List<String>.from(vehicleIds),
+        driverIds: List<String>.from(driverIds),
         addedByUserId: addedByUserId,
         addedTimestamp: addedTimestamp,
         closed: closed,

--- a/feature/grafik/form/strategy/supply_run_element_strategy.dart
+++ b/feature/grafik/form/strategy/supply_run_element_strategy.dart
@@ -24,6 +24,8 @@ class SupplyRunElementStrategy implements GrafikElementFormStrategy {
       additionalInfo: '',
       supplyOrderIds: const [],
       routeDescription: '',
+      vehicleIds: const [],
+      driverIds: const [],
       addedByUserId: '',
       addedTimestamp: DateTime.now(),
       closed: false,

--- a/feature/supplies/cubit/supply_run_planning_cubit.dart
+++ b/feature/supplies/cubit/supply_run_planning_cubit.dart
@@ -40,6 +40,14 @@ class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
     emit(state.copyWith(additionalInfo: info));
   }
 
+  void setVehicleIds(List<String> ids) {
+    emit(state.copyWith(selectedVehicleIds: ids.toSet()));
+  }
+
+  void setDriverIds(List<String> ids) {
+    emit(state.copyWith(selectedDriverIds: ids.toSet()));
+  }
+
   void setStartDateTime(DateTime start) {
     emit(state.copyWith(startDateTime: start));
   }
@@ -57,6 +65,8 @@ class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
       additionalInfo: state.additionalInfo,
       supplyOrderIds: state.selectedOrderIds.toList(),
       routeDescription: state.routeDescription,
+      vehicleIds: state.selectedVehicleIds.toList(),
+      driverIds: state.selectedDriverIds.toList(),
       addedByUserId: userId,
       addedTimestamp: DateTime.now(),
       closed: false,

--- a/feature/supplies/cubit/supply_run_planning_state.dart
+++ b/feature/supplies/cubit/supply_run_planning_state.dart
@@ -3,6 +3,8 @@ import '../../../domain/models/supply_order.dart';
 class SupplyRunPlanningState {
   final List<SupplyOrder> availableOrders;
   final Set<String> selectedOrderIds;
+  final Set<String> selectedVehicleIds;
+  final Set<String> selectedDriverIds;
   final String routeDescription;
   final String additionalInfo;
   final DateTime startDateTime;
@@ -14,6 +16,8 @@ class SupplyRunPlanningState {
   SupplyRunPlanningState({
     required this.availableOrders,
     required this.selectedOrderIds,
+    required this.selectedVehicleIds,
+    required this.selectedDriverIds,
     required this.routeDescription,
     required this.additionalInfo,
     required this.startDateTime,
@@ -28,6 +32,8 @@ class SupplyRunPlanningState {
     return SupplyRunPlanningState(
       availableOrders: const [],
       selectedOrderIds: {},
+      selectedVehicleIds: {},
+      selectedDriverIds: {},
       routeDescription: '',
       additionalInfo: '',
       startDateTime: now.add(const Duration(hours: 1)),
@@ -41,6 +47,8 @@ class SupplyRunPlanningState {
   SupplyRunPlanningState copyWith({
     List<SupplyOrder>? availableOrders,
     Set<String>? selectedOrderIds,
+    Set<String>? selectedVehicleIds,
+    Set<String>? selectedDriverIds,
     String? routeDescription,
     String? additionalInfo,
     DateTime? startDateTime,
@@ -52,6 +60,8 @@ class SupplyRunPlanningState {
     return SupplyRunPlanningState(
       availableOrders: availableOrders ?? this.availableOrders,
       selectedOrderIds: selectedOrderIds ?? this.selectedOrderIds,
+      selectedVehicleIds: selectedVehicleIds ?? this.selectedVehicleIds,
+      selectedDriverIds: selectedDriverIds ?? this.selectedDriverIds,
       routeDescription: routeDescription ?? this.routeDescription,
       additionalInfo: additionalInfo ?? this.additionalInfo,
       startDateTime: startDateTime ?? this.startDateTime,

--- a/feature/supplies/supply_run_planning_screen.dart
+++ b/feature/supplies/supply_run_planning_screen.dart
@@ -11,6 +11,10 @@ import '../supplies/cubit/supply_run_planning_state.dart';
 import '../../shared/app_drawer.dart';
 import '../../shared/responsive/responsive_layout.dart';
 import '../../shared/datetime/date_time_picker_field.dart';
+import '../employee/employee_picker.dart';
+import '../vehicle/widget/vehicle_picker.dart';
+import '../../data/repositories/employee_repository.dart';
+import '../../data/repositories/vehicle_repository.dart';
 import '../../theme/app_tokens.dart';
 
 class SupplyRunPlanningScreen extends StatefulWidget {
@@ -103,6 +107,27 @@ class _SupplyRunPlanningScreenState extends State<SupplyRunPlanningScreen> {
                             onChanged: cubit.setAdditionalInfo,
                             decoration: const InputDecoration(
                                 labelText: 'Dodatkowe informacje'),
+                          ),
+                          const SizedBox(height: AppSpacing.lg),
+                          EmployeePicker(
+                            singleSelection: true,
+                            employeeStream:
+                                GetIt.I<EmployeeRepository>().getEmployees(),
+                            initialSelectedIds:
+                                state.selectedDriverIds.toList(),
+                            onSelectionChanged: (drivers) =>
+                                cubit.setDriverIds(
+                                    drivers.map((e) => e.uid).toList()),
+                          ),
+                          const SizedBox(height: AppSpacing.lg),
+                          VehiclePicker(
+                            vehicleStream:
+                                GetIt.I<VehicleRepository>().getVehicles(),
+                            initialSelectedIds:
+                                state.selectedVehicleIds.toList(),
+                            onSelectionChanged: (vehicles) =>
+                                cubit.setVehicleIds(
+                                    vehicles.map((v) => v.id).toList()),
                           ),
                           const SizedBox(height: AppSpacing.lg),
                           DateTimePickerField(

--- a/test/domain/grafik/supply_run_to_task_test.dart
+++ b/test/domain/grafik/supply_run_to_task_test.dart
@@ -14,6 +14,8 @@ void main() {
       additionalInfo: 'info',
       supplyOrderIds: const ['o1', 'o2'],
       routeDescription: 'route',
+      vehicleIds: const ['v1'],
+      driverIds: const ['d1'],
       addedByUserId: 'u1',
       addedTimestamp: DateTime(2023, 1, 1),
       closed: false,


### PR DESCRIPTION
## Summary
- extend `SupplyRunElement` with `vehicleIds` and `driverIds`
- include new fields in DTOs and strategy
- track selected drivers and vehicles in supply run planning state and cubit
- add employee and vehicle pickers to planning screen
- update related test

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f28c57d0833381d9703b9ec4f1b0