### PR TITLE
Use closed status for supply runs

### DIFF
--- a/domain/models/grafik/impl/supply_run_to_task_extension.dart
+++ b/domain/models/grafik/impl/supply_run_to_task_extension.dart
@@ -9,7 +9,7 @@ extension SupplyRunToTask on SupplyRunElement {
   /// [orderId] and [carIds] must be provided to satisfy the task data.
   TaskElement toTaskElement({
     required String orderId,
-    GrafikStatus status = GrafikStatus.Realizacja,
+    GrafikStatus status = GrafikStatus.Zakonczone,
     List<String> carIds = const [],
   }) {
     return TaskElement(

--- a/feature/supplies/cubit/supply_run_planning_cubit.dart
+++ b/feature/supplies/cubit/supply_run_planning_cubit.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../domain/models/grafik/impl/supply_run_element.dart';
 import '../../../domain/models/grafik/impl/supply_run_to_task_extension.dart';
+import '../../../domain/models/grafik/enums.dart';
 import '../../../domain/models/supply_order.dart';
 import '../../../data/repositories/grafik_element_repository.dart';
 import '../../../domain/services/i_supply_repository.dart';
@@ -94,6 +95,7 @@ class SupplyRunPlanningCubit extends Cubit<SupplyRunPlanningState> {
     emit(state.copyWith(isSubmitting: true, success: false, errorMsg: null));
     final task = run.toTaskElement(
       orderId: orderId,
+      status: GrafikStatus.Zakonczone,
       carIds: carIds,
     );
     try {

--- a/test/domain/grafik/supply_run_to_task_test.dart
+++ b/test/domain/grafik/supply_run_to_task_test.dart
@@ -30,7 +30,7 @@ void main() {
     expect(task.taskType, GrafikTaskType.Zaopatrzenie);
     expect(task.orderId, 'ord');
     expect(task.carIds, ['c1']);
-    expect(task.status, GrafikStatus.Realizacja);
+    expect(task.status, GrafikStatus.Zakonczone);
     expect(task.closed, isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- default new tasks created from supply runs to `GrafikStatus.Zakonczone`
- ensure closing a supply run passes the closed status
- update test to expect closed status

## Testing
- `dart test` *(fails: No pubspec.yaml file found)*

------
https://chatgpt.com/codex/tasks/task_e_68824dbd2184833394bccf950aa0ac88