### PR TITLE
Add placeholder warehouse integration

### DIFF
--- a/data/repositories/supply_firebase_repository.dart
+++ b/data/repositories/supply_firebase_repository.dart
@@ -38,7 +38,16 @@ class SupplyFirebaseRepository implements ISupplyRepository {
   Future<void> placeOrder(SupplyOrder order) async {
     final dto = SupplyOrderDto.fromDomain(order);
     await _orders.add(dto.toJson());
-    // TODO: Integrate with external warehouse system via adapter
+    await sendToWarehouse(order);
+  }
+
+  /// Placeholder for sending orders to the external warehouse system.
+  ///
+  /// This method should be replaced by an implementation that delegates to a
+  /// dedicated service (e.g. `IWarehouseService`) responsible for talking to
+  /// the warehouse API.
+  Future<void> sendToWarehouse(SupplyOrder order) async {
+    // TODO(warehouse): connect to external warehouse system
   }
 
   @override

--- a/domain/services/i_warehouse_service.dart
+++ b/domain/services/i_warehouse_service.dart
@@ -1,0 +1,6 @@
+import '../models/supply_order.dart';
+
+/// Defines integration with an external warehouse system.
+abstract class IWarehouseService {
+  Future<void> sendOrder(SupplyOrder order);
+}


### PR DESCRIPTION
## Summary
- add new warehouse integration interface
- stub `sendToWarehouse` in `SupplyFirebaseRepository`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688260dac624833393d137ed1b972041