### PR TITLE
Add ServiceRequestElement data layer

### DIFF
--- a/data/dto/grafik/grafik_element_dto.dart
+++ b/data/dto/grafik/grafik_element_dto.dart
@@ -6,12 +6,14 @@ import '../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../../domain/models/grafik/impl/service_request_element.dart';
 import '../../../domain/models/grafik/enums.dart';
 import 'task_element_dto.dart';
 import 'time_issue_element_dto.dart';
 import 'delivery_planning_element_dto.dart';
 import 'task_planning_element_dto.dart';
 import 'supply_run_element_dto.dart';
+import 'service_request_element_dto.dart';
 
 abstract class GrafikElementDto {
   static DateTime parseDateTime(dynamic value, DateTime fallback) {
@@ -72,6 +74,9 @@ abstract class GrafikElementDto {
       case 'SupplyRunElement':
         return SupplyRunElementDto.fromDomain(
             element as SupplyRunElement);
+      case 'ServiceRequestElement':
+        return ServiceRequestElementDto.fromDomain(
+            element as ServiceRequestElement);
       case 'TaskPlanningElement':
         return TaskPlanningElementDto.fromDomain(
             element as TaskPlanningElement);
@@ -91,6 +96,8 @@ abstract class GrafikElementDto {
         return DeliveryPlanningElementDto.fromJson(json);
       case 'SupplyRunElement':
         return SupplyRunElementDto.fromJson(json);
+      case 'ServiceRequestElement':
+        return ServiceRequestElementDto.fromJson(json);
       case 'TaskPlanningElement':
         return TaskPlanningElementDto.fromJson(json);
       default:

--- a/data/dto/grafik/service_request_element_dto.dart
+++ b/data/dto/grafik/service_request_element_dto.dart
@@ -1,0 +1,128 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+import '../../../domain/models/grafik/enums.dart';
+import 'grafik_element_dto.dart';
+
+class ServiceRequestElementDto extends GrafikElementDto {
+  final String location;
+  final String description;
+  final String orderNumber;
+  final ServiceUrgency urgency;
+  final DateTime? suggestedDate;
+  final int estimatedDurationMinutes;
+  final int requiredPeopleCount;
+  final GrafikTaskType taskType;
+
+  ServiceRequestElementDto({
+    required super.id,
+    required super.startDateTime,
+    required super.endDateTime,
+    required super.type,
+    required super.additionalInfo,
+    required super.addedByUserId,
+    required super.addedTimestamp,
+    required super.closed,
+    required this.location,
+    required this.description,
+    required this.orderNumber,
+    required this.urgency,
+    this.suggestedDate,
+    required this.estimatedDurationMinutes,
+    required this.requiredPeopleCount,
+    required this.taskType,
+  });
+
+  factory ServiceRequestElementDto.fromJson(Map<String, dynamic> json) {
+    return ServiceRequestElementDto(
+      id: json['id'] as String? ?? '',
+      startDateTime: GrafikElementDto.parseDateTime(
+        json['startDateTime'],
+        DateTime.now(),
+      ),
+      endDateTime: GrafikElementDto.parseDateTime(
+        json['endDateTime'],
+        DateTime.now(),
+      ),
+      type: 'ServiceRequestElement',
+      additionalInfo: json['additionalInfo'] as String? ?? '',
+      addedByUserId: json['addedByUserId'] as String? ?? '',
+      addedTimestamp: GrafikElementDto.parseDateTime(
+        json['addedTimestamp'],
+        DateTime(1960, 2, 9),
+      ),
+      closed: json['closed'] as bool? ?? false,
+      location: json['location'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      orderNumber: json['orderNumber'] as String? ?? '',
+      urgency: ServiceUrgency.values.firstWhere(
+        (e) => e.name == (json['urgency'] ?? 'normal'),
+        orElse: () => ServiceUrgency.normal,
+      ),
+      suggestedDate: json['suggestedDate'] != null
+          ? GrafikElementDto.parseDateTime(json['suggestedDate'], DateTime.now())
+          : null,
+      estimatedDurationMinutes: json['estimatedDuration'] as int? ?? 0,
+      requiredPeopleCount: json['requiredPeopleCount'] as int? ?? 1,
+      taskType: GrafikTaskType.values.firstWhere(
+        (e) => e.name == (json['taskType'] ?? 'Serwis'),
+        orElse: () => GrafikTaskType.Serwis,
+      ),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ...baseToJson(),
+        'location': location,
+        'description': description,
+        'orderNumber': orderNumber,
+        'urgency': urgency.name,
+        'suggestedDate':
+            suggestedDate != null ? Timestamp.fromDate(suggestedDate!) : null,
+        'estimatedDuration': estimatedDurationMinutes,
+        'requiredPeopleCount': requiredPeopleCount,
+        'taskType': taskType.name,
+      };
+
+  @override
+  ServiceRequestElement toDomain() => ServiceRequestElement(
+        id: id,
+        createdBy: addedByUserId,
+        createdAt: addedTimestamp,
+        location: location,
+        description: description,
+        orderNumber: orderNumber,
+        urgency: urgency,
+        suggestedDate: suggestedDate,
+        estimatedDuration: Duration(minutes: estimatedDurationMinutes),
+        requiredPeopleCount: requiredPeopleCount,
+        taskType: taskType,
+      );
+
+  static ServiceRequestElementDto fromDomain(ServiceRequestElement element) =>
+      ServiceRequestElementDto(
+        id: element.id,
+        startDateTime: element.startDateTime,
+        endDateTime: element.endDateTime,
+        type: element.type,
+        additionalInfo: element.additionalInfo,
+        addedByUserId: element.addedByUserId,
+        addedTimestamp: element.addedTimestamp,
+        closed: element.closed,
+        location: element.location,
+        description: element.description,
+        orderNumber: element.orderNumber,
+        urgency: element.urgency,
+        suggestedDate: element.suggestedDate,
+        estimatedDurationMinutes: element.estimatedDuration.inMinutes,
+        requiredPeopleCount: element.requiredPeopleCount,
+        taskType: element.taskType,
+      );
+
+  static ServiceRequestElementDto fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    data['id'] = doc.id;
+    return ServiceRequestElementDto.fromJson(data);
+  }
+}

--- a/data/repositories/service_request_repository.dart
+++ b/data/repositories/service_request_repository.dart
@@ -1,0 +1,20 @@
+import '../../domain/models/grafik/impl/service_request_element.dart';
+import '../../domain/services/i_service_request_service.dart';
+
+class ServiceRequestRepository {
+  final IServiceRequestService _service;
+
+  ServiceRequestRepository(this._service);
+
+  Stream<List<ServiceRequestElement>> watchServiceRequests() {
+    return _service.watchServiceRequests();
+  }
+
+  Future<void> saveServiceRequest(ServiceRequestElement request) {
+    return _service.upsertServiceRequest(request);
+  }
+
+  Future<void> deleteServiceRequest(String id) {
+    return _service.deleteServiceRequest(id);
+  }
+}

--- a/data/services/firebase/service_request_firebase_service.dart
+++ b/data/services/firebase/service_request_firebase_service.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+import '../../dto/grafik/service_request_element_dto.dart';
+import '../../../domain/services/i_service_request_service.dart';
+
+class ServiceRequestFirebaseService implements IServiceRequestService {
+  final FirebaseFirestore _firestore;
+
+  ServiceRequestFirebaseService(this._firestore);
+
+  CollectionReference get _col => _firestore.collection('service_requests');
+
+  @override
+  Stream<List<ServiceRequestElement>> watchServiceRequests() {
+    return _col.snapshots().map((query) => query.docs
+        .map((doc) =>
+            ServiceRequestElementDto.fromFirestore(doc).toDomain())
+        .toList());
+  }
+
+  @override
+  Future<void> upsertServiceRequest(ServiceRequestElement request) async {
+    final dto = ServiceRequestElementDto.fromDomain(request);
+    if (request.id.isEmpty) {
+      final ref = await _col.add(dto.toJson());
+      await ref.update({'id': ref.id});
+    } else {
+      await _col.doc(request.id).set(dto.toJson());
+    }
+  }
+
+  @override
+  Future<void> deleteServiceRequest(String id) => _col.doc(id).delete();
+}

--- a/domain/models/grafik/enums.dart
+++ b/domain/models/grafik/enums.dart
@@ -44,3 +44,9 @@ enum DeliveryPlanningCategory {
   Inne,
 }
 
+/// Urgency level for [ServiceRequestElement].
+enum ServiceUrgency {
+  normal,
+  pilne,
+}
+

--- a/domain/models/grafik/impl/service_request_element.dart
+++ b/domain/models/grafik/impl/service_request_element.dart
@@ -1,0 +1,41 @@
+import '../grafik_element.dart';
+import '../enums.dart';
+
+/// Service request reported by a user.
+///
+/// Unlike [TaskElement], this element represents a request that is not yet
+/// scheduled on the grafik.
+class ServiceRequestElement extends GrafikElement {
+  final String location;
+  final String description;
+  final String orderNumber;
+  final ServiceUrgency urgency;
+  final DateTime? suggestedDate;
+  final Duration estimatedDuration;
+  final int requiredPeopleCount;
+  final GrafikTaskType taskType;
+
+  ServiceRequestElement({
+    required String id,
+    required String createdBy,
+    required DateTime createdAt,
+    required this.location,
+    required this.description,
+    required this.orderNumber,
+    this.urgency = ServiceUrgency.normal,
+    this.suggestedDate,
+    required this.estimatedDuration,
+    required this.requiredPeopleCount,
+    this.taskType = GrafikTaskType.Serwis,
+  }) : super(
+          id: id,
+          startDateTime: suggestedDate ?? createdAt,
+          endDateTime:
+              (suggestedDate ?? createdAt).add(estimatedDuration),
+          type: 'ServiceRequestElement',
+          additionalInfo: description,
+          addedByUserId: createdBy,
+          addedTimestamp: createdAt,
+          closed: false,
+        );
+}

--- a/domain/services/i_service_request_service.dart
+++ b/domain/services/i_service_request_service.dart
@@ -1,0 +1,7 @@
+import '../models/grafik/impl/service_request_element.dart';
+
+abstract class IServiceRequestService {
+  Stream<List<ServiceRequestElement>> watchServiceRequests();
+  Future<void> upsertServiceRequest(ServiceRequestElement request);
+  Future<void> deleteServiceRequest(String id);
+}

--- a/injection.dart
+++ b/injection.dart
@@ -26,6 +26,9 @@ import 'package:kabast/domain/services/i_grafik_element_service.dart';
 import 'package:kabast/data/repositories/supply_firebase_repository.dart';
 import 'package:kabast/data/repositories/supply_order_repository.dart';
 import 'package:kabast/domain/services/i_supply_repository.dart';
+import 'package:kabast/data/services/firebase/service_request_firebase_service.dart';
+import 'package:kabast/data/repositories/service_request_repository.dart';
+import 'package:kabast/domain/services/i_service_request_service.dart';
 
 
 import 'package:kabast/data/services/task_assignment_firebase_service.dart';
@@ -67,6 +70,10 @@ Future<void> setupLocator() async {
     () => SupplyFirebaseRepository(getIt<FirebaseFirestore>()),
   );
 
+  getIt.registerLazySingleton<IServiceRequestService>(
+    () => ServiceRequestFirebaseService(getIt<FirebaseFirestore>()),
+  );
+
   getIt.registerLazySingleton<SupplyOrderRepository>(
     () => SupplyOrderRepository(getIt<FirebaseFirestore>()),
   );
@@ -89,6 +96,9 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<TaskAssignmentRepository>(
     () => TaskAssignmentRepository(getIt<ITaskAssignmentService>()),
+  );
+  getIt.registerLazySingleton<ServiceRequestRepository>(
+    () => ServiceRequestRepository(getIt<IServiceRequestService>()),
   );
   getIt.registerLazySingleton<IGrafikResolver>(
     () => GrafikResolver(getIt<GrafikElementRepository>()),

--- a/test/data/dto/service_request_element_dto_test.dart
+++ b/test/data/dto/service_request_element_dto_test.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+
+import 'package:kabast/domain/models/grafik/impl/service_request_element.dart';
+import 'package:kabast/domain/models/grafik/enums.dart';
+import 'package:kabast/data/dto/grafik/service_request_element_dto.dart';
+
+void main() {
+  test('service request dto serialization round trip', () {
+    final req = ServiceRequestElement(
+      id: 'r1',
+      createdBy: 'u1',
+      createdAt: DateTime(2024, 1, 1),
+      location: 'loc',
+      description: 'desc',
+      orderNumber: 'ord1',
+      urgency: ServiceUrgency.pilne,
+      suggestedDate: DateTime(2024, 1, 10),
+      estimatedDuration: const Duration(minutes: 90),
+      requiredPeopleCount: 2,
+    );
+
+    final dto = ServiceRequestElementDto.fromDomain(req);
+    final json = dto.toJson();
+    final recreated = ServiceRequestElementDto.fromJson(json).toDomain();
+
+    expect(recreated.location, req.location);
+    expect(recreated.description, req.description);
+    expect(recreated.orderNumber, req.orderNumber);
+    expect(recreated.urgency, req.urgency);
+    expect(recreated.suggestedDate, req.suggestedDate);
+    expect(recreated.estimatedDuration, req.estimatedDuration);
+    expect(recreated.requiredPeopleCount, req.requiredPeopleCount);
+  });
+}


### PR DESCRIPTION
## Summary
- add `ServiceRequestElement` domain model
- support ServiceUrgency enum
- implement DTO and Firestore service for service requests
- create repository and register in dependency injection
- extend `GrafikElementDto` switch to handle new type
- add unit test covering DTO serialization

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882887720548333a2ac3c3660777b50