### PR TITLE
Add serwisant role

### DIFF
--- a/data/dto/app_user_dto.dart
+++ b/data/dto/app_user_dto.dart
@@ -80,6 +80,8 @@ UserRole _stringToUserRole(String? value) {
       return UserRole.kierownik;
     case 'kierownikProdukcji':
       return UserRole.kierownikProdukcji;
+    case 'serwisant':
+      return UserRole.serwisant;
     case 'monter':
       return UserRole.monter;
     case 'hala':
@@ -103,6 +105,8 @@ String _userRoleToString(UserRole role) {
       return 'kierownik';
     case UserRole.kierownikProdukcji:
       return 'kierownikProdukcji';
+    case UserRole.serwisant:
+      return 'serwisant';
     case UserRole.monter:
       return 'monter';
     case UserRole.hala:

--- a/domain/models/app_user.dart
+++ b/domain/models/app_user.dart
@@ -4,6 +4,7 @@ enum UserRole {
   czlowiekZarzadu,
   kierownik,
   kierownikProdukcji,
+  serwisant,
   monter,
   hala,
   user,
@@ -106,6 +107,23 @@ Map<String, bool> getDefaultPermissionsForRole(UserRole role) {
         'canSeeAllGrafik': true,
         'canApprove': true,
         'canPlanSupplyRun': true,
+        'canUseApp': true,
+      };
+    case UserRole.serwisant:
+      return {
+        'canEditGrafik': false,
+        'canAddGrafik': false,
+        'canSuggestGrafik': false,
+        'canSeeWeeklySummary': false,
+        'canViewServiceTasks': true,
+        'canCreateServiceTasks': false,
+        'canEditServiceRequests': true,
+        'canEditSettings': false,
+        'canLogout': true,
+        'canChangeDate': true,
+        'canSeeAllGrafik': false,
+        'canApprove': false,
+        'canPlanSupplyRun': false,
         'canUseApp': true,
       };
     default:


### PR DESCRIPTION
## Summary
- extend `UserRole` enum with a new `serwisant` value
- define default permissions for the serwisant role
- support serwisant in AppUserDto serialization

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688320adbd2c8333aaf1805fe118cbed