### PR TITLE
Add service request list screen

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -14,6 +14,7 @@ import 'feature/assign_employee/assign_employee_screen.dart';
 import 'feature/my_tasks/assign_employee_screen.dart';
 import 'feature/admin/admin_panel_screen.dart';
 import 'feature/service/screens/service_request_form_screen.dart';
+import 'feature/service/screens/service_request_list_screen.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -49,6 +50,10 @@ class AppRouter {
             builder: (_) => const SupplyRunApprovalScreen());
       case '/admin':
         return MaterialPageRoute(builder: (_) => const AdminPanelScreen());
+      case '/serviceRequests':
+        return MaterialPageRoute(
+          builder: (_) => const ServiceRequestListScreen(),
+        );
       case '/serviceRequest/new':
         return MaterialPageRoute(
           builder: (_) => const ServiceRequestFormScreen(),

--- a/feature/service/screens/service_request_list_screen.dart
+++ b/feature/service/screens/service_request_list_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../../data/repositories/service_request_repository.dart';
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+import '../../auth/auth_cubit.dart';
+import '../../auth/screen/no_access_screen.dart';
+import '../../../shared/app_drawer.dart';
+import '../../../shared/responsive/responsive_layout.dart';
+
+class ServiceRequestListScreen extends StatelessWidget {
+  const ServiceRequestListScreen({super.key});
+
+  Stream<List<ServiceRequestElement>> _openRequests(ServiceRequestRepository repo) {
+    return repo
+        .watchServiceRequests()
+        .map((list) => list.where((r) => !r.closed).toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = context.watch<AuthCubit>().currentUser;
+    final hasPermission =
+        user?.effectivePermissions['canViewServiceTasks'] ?? false;
+    if (user == null || !hasPermission) {
+      return const NoAccessScreen();
+    }
+
+    final repo = GetIt.I<ServiceRequestRepository>();
+
+    return ResponsiveScaffold(
+      drawer: const AppDrawer(),
+      appBar: AppBar(
+        title: const Text('Zlecenia serwisowe'),
+      ),
+      body: StreamBuilder<List<ServiceRequestElement>>(
+        stream: _openRequests(repo),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(child: Text('B\u0142\u0105d danych\n${snapshot.error}'));
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final requests = snapshot.data!;
+          if (requests.isEmpty) {
+            return const Center(child: Text('Brak otwartych zg\u0142osze\u0144'));
+          }
+          return ListView.builder(
+            itemCount: requests.length,
+            itemBuilder: (context, index) {
+              final req = requests[index];
+              return ListTile(
+                title: Text(req.orderNumber.isEmpty
+                    ? '(brak numeru)'
+                    : req.orderNumber),
+                subtitle: Text(req.description),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => _ServiceRequestDetailScreen(request: req),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ServiceRequestDetailScreen extends StatelessWidget {
+  final ServiceRequestElement request;
+  const _ServiceRequestDetailScreen({required this.request});
+
+  @override
+  Widget build(BuildContext context) {
+    return ResponsiveScaffold(
+      appBar: AppBar(title: Text('Zg\u0142oszenie ${request.orderNumber}')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Lokalizacja: ${request.location}'),
+            const SizedBox(height: 8),
+            Text('Opis: ${request.description}'),
+            const SizedBox(height: 8),
+            Text('Pilno\u015b\u0107: ${request.urgency.name}'),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new screen for listing service requests
- gate screen by permission `canViewServiceTasks`
- show detail view when tapping a request
- register new route `/serviceRequests`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688320b478b08333adacf656d356ed55