### PR TITLE
Add service request details editor

### DIFF
--- a/feature/service/cubit/service_request_details_cubit.dart
+++ b/feature/service/cubit/service_request_details_cubit.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../data/repositories/service_request_repository.dart';
+import '../../../domain/models/grafik/enums.dart';
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+
+class ServiceRequestDetailsState {
+  final String id;
+  final String createdBy;
+  final DateTime createdAt;
+  final String location;
+  final String description;
+  final String orderNumber;
+  final ServiceUrgency urgency;
+  final DateTime? suggestedDate;
+  final int durationMinutes;
+  final int peopleCount;
+  final GrafikTaskType taskType;
+  final bool isSubmitting;
+  final bool success;
+  final String? errorMsg;
+
+  ServiceRequestDetailsState({
+    required this.id,
+    required this.createdBy,
+    required this.createdAt,
+    required this.location,
+    required this.description,
+    required this.orderNumber,
+    required this.urgency,
+    required this.suggestedDate,
+    required this.durationMinutes,
+    required this.peopleCount,
+    required this.taskType,
+    this.isSubmitting = false,
+    this.success = false,
+    this.errorMsg,
+  });
+
+  factory ServiceRequestDetailsState.fromRequest(ServiceRequestElement r) {
+    return ServiceRequestDetailsState(
+      id: r.id,
+      createdBy: r.addedByUserId,
+      createdAt: r.addedTimestamp,
+      location: r.location,
+      description: r.description,
+      orderNumber: r.orderNumber,
+      urgency: r.urgency,
+      suggestedDate: r.suggestedDate,
+      durationMinutes: r.estimatedDuration.inMinutes,
+      peopleCount: r.requiredPeopleCount,
+      taskType: r.taskType,
+    );
+  }
+
+  ServiceRequestDetailsState copyWith({
+    String? location,
+    String? description,
+    String? orderNumber,
+    ServiceUrgency? urgency,
+    DateTime? suggestedDate,
+    int? durationMinutes,
+    int? peopleCount,
+    bool? isSubmitting,
+    bool? success,
+    String? errorMsg,
+  }) {
+    return ServiceRequestDetailsState(
+      id: id,
+      createdBy: createdBy,
+      createdAt: createdAt,
+      location: location ?? this.location,
+      description: description ?? this.description,
+      orderNumber: orderNumber ?? this.orderNumber,
+      urgency: urgency ?? this.urgency,
+      suggestedDate: suggestedDate ?? this.suggestedDate,
+      durationMinutes: durationMinutes ?? this.durationMinutes,
+      peopleCount: peopleCount ?? this.peopleCount,
+      taskType: taskType,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      success: success ?? this.success,
+      errorMsg: errorMsg,
+    );
+  }
+}
+
+class ServiceRequestDetailsCubit extends Cubit<ServiceRequestDetailsState> {
+  final ServiceRequestRepository _repo;
+
+  ServiceRequestDetailsCubit(this._repo, ServiceRequestElement request)
+      : super(ServiceRequestDetailsState.fromRequest(request));
+
+  void setLocation(String val) => emit(state.copyWith(location: val));
+  void setDescription(String val) => emit(state.copyWith(description: val));
+  void setOrderNumber(String val) => emit(state.copyWith(orderNumber: val));
+  void setUrgency(ServiceUrgency val) => emit(state.copyWith(urgency: val));
+  void setSuggestedDate(DateTime? date) =>
+      emit(state.copyWith(suggestedDate: date));
+  void setDurationMinutes(int val) => emit(state.copyWith(durationMinutes: val));
+  void setPeopleCount(int val) => emit(state.copyWith(peopleCount: val));
+
+  Future<void> save() async {
+    if (state.durationMinutes <= 0 || state.peopleCount < 1) {
+      emit(state.copyWith(errorMsg: 'Niepoprawne dane'));
+      return;
+    }
+
+    emit(state.copyWith(isSubmitting: true, success: false, errorMsg: null));
+    final element = ServiceRequestElement(
+      id: state.id,
+      createdBy: state.createdBy,
+      createdAt: state.createdAt,
+      location: state.location,
+      description: state.description,
+      orderNumber: state.orderNumber,
+      urgency: state.urgency,
+      suggestedDate: state.suggestedDate,
+      estimatedDuration: Duration(minutes: state.durationMinutes),
+      requiredPeopleCount: state.peopleCount,
+      taskType: state.taskType,
+    );
+    try {
+      await _repo.saveServiceRequest(element);
+      emit(state.copyWith(isSubmitting: false, success: true));
+    } catch (e) {
+      emit(state.copyWith(
+          isSubmitting: false, success: false, errorMsg: e.toString()));
+    }
+  }
+}

--- a/feature/service/screens/service_request_details_screen.dart
+++ b/feature/service/screens/service_request_details_screen.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../../data/repositories/service_request_repository.dart';
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+import '../../auth/auth_cubit.dart';
+import '../cubit/service_request_details_cubit.dart';
+import '../../../shared/form/custom_textfield.dart';
+import '../../../shared/form/enum_picker/enum_picker.dart';
+import '../../../shared/form/minutes_picker/minutes_picker_field.dart';
+import '../../../shared/form/small_number_picker/small_number_picker.dart';
+import '../../../shared/form/standard/standard_form_field.dart';
+import '../../../shared/form/standard/standard_form_section.dart';
+import '../../../shared/responsive/responsive_layout.dart';
+
+class ServiceRequestDetailsScreen extends StatelessWidget {
+  final ServiceRequestElement request;
+  const ServiceRequestDetailsScreen({super.key, required this.request});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => ServiceRequestDetailsCubit(
+        GetIt.I<ServiceRequestRepository>(),
+        request,
+      ),
+      child: const _ServiceRequestDetailsView(),
+    );
+  }
+}
+
+class _ServiceRequestDetailsView extends StatelessWidget {
+  const _ServiceRequestDetailsView();
+
+  @override
+  Widget build(BuildContext context) {
+    final canEdit = context.select<AuthCubit, bool>((cubit) =>
+        cubit.currentUser?.effectivePermissions['canEditServiceRequests'] ??
+        false);
+    return BlocListener<ServiceRequestDetailsCubit, ServiceRequestDetailsState>(
+      listener: (context, state) {
+        if (state.success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Zapisano zgłoszenie')),
+          );
+        } else if (state.errorMsg != null && !state.isSubmitting) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.errorMsg!),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      },
+      child: BlocBuilder<ServiceRequestDetailsCubit, ServiceRequestDetailsState>(
+        builder: (context, state) {
+          final cubit = context.read<ServiceRequestDetailsCubit>();
+          return ResponsiveScaffold(
+            appBar: AppBar(
+              title: Text('Zgłoszenie ${state.orderNumber}'),
+            ),
+            body: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: StandardFormSection(
+                fields: [
+                  StandardFormField(
+                    label: 'Lokalizacja',
+                    child: canEdit
+                        ? CustomTextField(
+                            label: 'Lokalizacja',
+                            initialValue: state.location,
+                            onChanged: cubit.setLocation,
+                          )
+                        : Text(state.location),
+                  ),
+                  StandardFormField(
+                    label: 'Nr zlecenia',
+                    child: canEdit
+                        ? CustomTextField(
+                            label: 'Nr zlecenia',
+                            initialValue: state.orderNumber,
+                            onChanged: cubit.setOrderNumber,
+                          )
+                        : Text(state.orderNumber),
+                  ),
+                  StandardFormField(
+                    label: 'Pilność',
+                    child: canEdit
+                        ? EnumPicker<ServiceUrgency>(
+                            label: '',
+                            values: ServiceUrgency.values,
+                            initialValue: state.urgency,
+                            onChanged: cubit.setUrgency,
+                          )
+                        : Text(state.urgency.name),
+                  ),
+                  StandardFormField(
+                    label: 'Opis',
+                    child: canEdit
+                        ? TextField(
+                            minLines: 2,
+                            maxLines: 5,
+                            onChanged: cubit.setDescription,
+                            controller:
+                                TextEditingController(text: state.description),
+                            decoration: const InputDecoration(labelText: 'Opis'),
+                          )
+                        : Text(state.description),
+                  ),
+                  StandardFormField(
+                    label: 'Czas trwania',
+                    child: canEdit
+                        ? MinutesPickerField(
+                            minutes: state.durationMinutes,
+                            onChanged: cubit.setDurationMinutes,
+                          )
+                        : Text('${state.durationMinutes} min'),
+                  ),
+                  StandardFormField(
+                    label: 'Liczba osób',
+                    child: canEdit
+                        ? SmallNumberPicker(
+                            initialValue: state.peopleCount,
+                            min: 1,
+                            onChanged: cubit.setPeopleCount,
+                          )
+                        : Text('${state.peopleCount}'),
+                  ),
+                  if (canEdit)
+                    StandardFormField(
+                      label: '',
+                      child: ElevatedButton(
+                        onPressed: state.isSubmitting ? null : cubit.save,
+                        child: const Text('Zapisz'),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/feature/service/screens/service_request_list_screen.dart
+++ b/feature/service/screens/service_request_list_screen.dart
@@ -8,6 +8,7 @@ import '../../auth/auth_cubit.dart';
 import '../../auth/screen/no_access_screen.dart';
 import '../../../shared/app_drawer.dart';
 import '../../../shared/responsive/responsive_layout.dart';
+import 'service_request_details_screen.dart';
 
 class ServiceRequestListScreen extends StatelessWidget {
   const ServiceRequestListScreen({super.key});
@@ -59,7 +60,7 @@ class ServiceRequestListScreen extends StatelessWidget {
                 onTap: () {
                   Navigator.of(context).push(
                     MaterialPageRoute(
-                      builder: (_) => _ServiceRequestDetailScreen(request: req),
+                      builder: (_) => ServiceRequestDetailsScreen(request: req),
                     ),
                   );
                 },
@@ -72,27 +73,3 @@ class ServiceRequestListScreen extends StatelessWidget {
   }
 }
 
-class _ServiceRequestDetailScreen extends StatelessWidget {
-  final ServiceRequestElement request;
-  const _ServiceRequestDetailScreen({required this.request});
-
-  @override
-  Widget build(BuildContext context) {
-    return ResponsiveScaffold(
-      appBar: AppBar(title: Text('Zg\u0142oszenie ${request.orderNumber}')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Lokalizacja: ${request.location}'),
-            const SizedBox(height: 8),
-            Text('Opis: ${request.description}'),
-            const SizedBox(height: 8),
-            Text('Pilno\u015b\u0107: ${request.urgency.name}'),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/test/feature/service/service_request_details_cubit_test.dart
+++ b/test/feature/service/service_request_details_cubit_test.dart
@@ -1,0 +1,62 @@
+import 'package:test/test.dart';
+
+import 'package:kabast/feature/service/cubit/service_request_details_cubit.dart';
+import 'package:kabast/data/repositories/service_request_repository.dart';
+import 'package:kabast/domain/services/i_service_request_service.dart';
+import 'package:kabast/domain/models/grafik/impl/service_request_element.dart';
+import 'package:kabast/domain/models/grafik/enums.dart';
+
+class _FakeService implements IServiceRequestService {
+  ServiceRequestElement? saved;
+  @override
+  Stream<List<ServiceRequestElement>> watchServiceRequests() => const Stream.empty();
+  @override
+  Future<void> upsertServiceRequest(ServiceRequestElement request) async {
+    saved = request;
+  }
+  @override
+  Future<void> deleteServiceRequest(String id) async {}
+}
+
+void main() {
+  final request = ServiceRequestElement(
+    id: 'r1',
+    createdBy: 'u1',
+    createdAt: DateTime(2024, 1, 1),
+    location: 'loc',
+    description: 'desc',
+    orderNumber: 'o1',
+    urgency: ServiceUrgency.normal,
+    estimatedDuration: const Duration(minutes: 60),
+    requiredPeopleCount: 1,
+  );
+
+  test('saves edited request', () async {
+    final service = _FakeService();
+    final repo = ServiceRequestRepository(service);
+    final cubit = ServiceRequestDetailsCubit(repo, request);
+
+    cubit.setDurationMinutes(90);
+    cubit.setPeopleCount(2);
+
+    await cubit.save();
+
+    expect(service.saved, isNotNull);
+    expect(service.saved!.estimatedDuration, const Duration(minutes: 90));
+    expect(service.saved!.requiredPeopleCount, 2);
+  });
+
+  test('validation prevents save', () async {
+    final service = _FakeService();
+    final repo = ServiceRequestRepository(service);
+    final cubit = ServiceRequestDetailsCubit(repo, request);
+
+    cubit.setDurationMinutes(0);
+    cubit.setPeopleCount(0);
+
+    await cubit.save();
+
+    expect(service.saved, isNull);
+    expect(cubit.state.errorMsg, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add cubit for editing service requests
- show details screen guarded by `canEditServiceRequests`
- open new screen from the list
- test cubit logic

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68832bac65b483338bdadc765fadc68a