### PR TITLE
Add service request routes and drawer links

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -15,6 +15,8 @@ import 'feature/my_tasks/assign_employee_screen.dart';
 import 'feature/admin/admin_panel_screen.dart';
 import 'feature/service/screens/service_request_form_screen.dart';
 import 'feature/service/screens/service_request_list_screen.dart';
+import 'feature/service/screens/service_request_details_screen.dart';
+import 'domain/models/grafik/impl/service_request_element.dart';
 
 class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -66,6 +68,14 @@ class AppRouter {
           ),
         );
       default:
+        final name = settings.name ?? '';
+        final match = RegExp(r'^/serviceRequest/([^/]+)$').firstMatch(name);
+        if (match != null) {
+          final request = settings.arguments as ServiceRequestElement;
+          return MaterialPageRoute(
+            builder: (_) => ServiceRequestDetailsScreen(request: request),
+          );
+        }
         return MaterialPageRoute(builder: (_) => const LoginScreen());
     }
   }

--- a/feature/service/screens/service_request_list_screen.dart
+++ b/feature/service/screens/service_request_list_screen.dart
@@ -58,10 +58,10 @@ class ServiceRequestListScreen extends StatelessWidget {
                     : req.orderNumber),
                 subtitle: Text(req.description),
                 onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => ServiceRequestDetailsScreen(request: req),
-                    ),
+                  Navigator.pushNamed(
+                    context,
+                    '/serviceRequest/${req.id}',
+                    arguments: req,
                   );
                 },
               );

--- a/shared/app_drawer.dart
+++ b/shared/app_drawer.dart
@@ -71,6 +71,20 @@ class AppDrawer extends StatelessWidget {
                   },
                 ),
                 PermissionWidget(
+                  permission: 'canViewServiceTasks',
+                  child: ListTile(
+                    hoverColor: colorScheme.primaryContainer,
+                    selectedTileColor: colorScheme.primaryContainer,
+                    leading: Icon(Icons.list, color: colorScheme.primary),
+                    title: Text('Zlecenia serwisowe',
+                        style: TextStyle(color: colorScheme.onSurface)),
+                    onTap: () {
+                      Navigator.pop(context);
+                      Navigator.pushNamed(context, '/serviceRequests');
+                    },
+                  ),
+                ),
+                PermissionWidget(
                   permission: 'canCreateServiceTasks',
                   child: ListTile(
                     hoverColor: colorScheme.primaryContainer,


### PR DESCRIPTION
## Summary
- route /serviceRequest/:id for service request details
- allow navigation to service request list in drawer
- open service requests with named routes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68832dcc7c3c8333884a960964e1e007