### PR TITLE
Add service request to task extension

### DIFF
--- a/domain/models/grafik/impl/service_request_to_task_extension.dart
+++ b/domain/models/grafik/impl/service_request_to_task_extension.dart
@@ -1,0 +1,26 @@
+import 'task_element.dart';
+import 'service_request_element.dart';
+import '../enums.dart';
+
+/// Conversion from [ServiceRequestElement] to [TaskElement].
+extension ServiceRequestToTask on ServiceRequestElement {
+  /// Create a [TaskElement] representing this service request.
+  TaskElement toTaskElement({
+    GrafikStatus status = GrafikStatus.Realizacja,
+    List<String> carIds = const [],
+  }) {
+    return TaskElement(
+      id: '',
+      startDateTime: startDateTime,
+      endDateTime: endDateTime,
+      additionalInfo: description,
+      orderId: orderNumber,
+      status: status,
+      taskType: GrafikTaskType.Serwis,
+      carIds: carIds,
+      addedByUserId: addedByUserId,
+      addedTimestamp: addedTimestamp,
+      closed: false,
+    );
+  }
+}

--- a/test/domain/grafik/service_request_to_task_test.dart
+++ b/test/domain/grafik/service_request_to_task_test.dart
@@ -1,0 +1,35 @@
+import 'package:test/test.dart';
+
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+import '../../../domain/models/grafik/impl/service_request_to_task_extension.dart';
+import '../../../domain/models/grafik/impl/task_element.dart';
+import '../../../domain/models/grafik/enums.dart';
+
+void main() {
+  test('converts service request to task element', () {
+    final req = ServiceRequestElement(
+      id: 'r1',
+      createdBy: 'u1',
+      createdAt: DateTime(2024, 1, 1),
+      location: 'loc',
+      description: 'desc',
+      orderNumber: 'ord1',
+      urgency: ServiceUrgency.normal,
+      suggestedDate: DateTime(2024, 1, 2),
+      estimatedDuration: const Duration(minutes: 90),
+      requiredPeopleCount: 2,
+    );
+
+    final task = req.toTaskElement();
+
+    expect(task.startDateTime, req.startDateTime);
+    expect(task.endDateTime, req.endDateTime);
+    expect(task.additionalInfo, req.description);
+    expect(task.orderId, req.orderNumber);
+    expect(task.taskType, GrafikTaskType.Serwis);
+    expect(task.status, GrafikStatus.Realizacja);
+    expect(task.carIds, isEmpty);
+    expect(task.addedByUserId, req.addedByUserId);
+    expect(task.closed, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `service_request_to_task_extension` for mapping service requests into tasks
- test service request → task mapping

## Testing
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836413be588333945efd5e1ad7e63a