### PR TITLE
Add service request approval flow

### DIFF
--- a/app_router.dart
+++ b/app_router.dart
@@ -10,6 +10,7 @@ import 'feature/my_tasks/my_tasks_screen.dart';
 import 'feature/supplies/supply_list_screen.dart';
 import 'feature/supplies/supply_run_planning_screen.dart';
 import 'feature/supplies/supply_run_approval_screen.dart';
+import 'feature/service/screens/service_request_approval_screen.dart';
 import 'feature/assign_employee/assign_employee_screen.dart';
 import 'feature/my_tasks/assign_employee_screen.dart';
 import 'feature/admin/admin_panel_screen.dart';
@@ -50,6 +51,9 @@ class AppRouter {
       case '/approveSupplyRuns':
         return MaterialPageRoute(
             builder: (_) => const SupplyRunApprovalScreen());
+      case '/approveServiceRequests':
+        return MaterialPageRoute(
+            builder: (_) => const ServiceRequestApprovalScreen());
       case '/admin':
         return MaterialPageRoute(builder: (_) => const AdminPanelScreen());
       case '/serviceRequests':

--- a/feature/service/screens/service_request_approval_screen.dart
+++ b/feature/service/screens/service_request_approval_screen.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../../data/repositories/grafik_element_repository.dart';
+import '../../../data/repositories/service_request_repository.dart';
+import '../../../data/repositories/task_assignment_repository.dart';
+import '../../../data/repositories/employee_repository.dart';
+import '../../../domain/models/app_user.dart';
+import '../../../domain/models/employee.dart';
+import '../../../domain/models/grafik/impl/service_request_element.dart';
+import '../../../domain/models/grafik/impl/service_request_to_task_extension.dart';
+import '../../../domain/models/grafik/task_assignment.dart';
+import '../../auth/auth_cubit.dart';
+import '../../auth/screen/no_access_screen.dart';
+import '../../employee/employee_picker.dart';
+import '../../../shared/app_drawer.dart';
+import '../../../shared/responsive/responsive_layout.dart';
+import '../../../theme/app_tokens.dart';
+
+class ServiceRequestApprovalScreen extends StatelessWidget {
+  const ServiceRequestApprovalScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = context.watch<AuthCubit>().currentUser;
+    if (user == null ||
+        (user.role != UserRole.kierownik &&
+            user.role != UserRole.kierownikProdukcji &&
+            user.role != UserRole.admin)) {
+      return const NoAccessScreen();
+    }
+
+    return BlocProvider(
+      create: (_) => ServiceRequestApprovalCubit(
+        GetIt.I<GrafikElementRepository>(),
+        GetIt.I<TaskAssignmentRepository>(),
+        GetIt.I<ServiceRequestRepository>(),
+      ),
+      child: const _ServiceRequestApprovalView(),
+    );
+  }
+}
+
+class _ServiceRequestApprovalView extends StatelessWidget {
+  const _ServiceRequestApprovalView();
+
+  Stream<List<ServiceRequestElement>> _requests(
+      ServiceRequestRepository repo) {
+    return repo.watchServiceRequests();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reqRepo = GetIt.I<ServiceRequestRepository>();
+    final empRepo = GetIt.I<EmployeeRepository>();
+
+    return BlocListener<ServiceRequestApprovalCubit, ServiceRequestApprovalState>(
+      listener: (context, state) {
+        if (state.success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Zgłoszenie zatwierdzone')),
+          );
+        } else if (state.errorMsg != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Błąd: ${state.errorMsg}'),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
+      },
+      child: ResponsiveScaffold(
+        drawer: const AppDrawer(),
+        appBar: AppBar(
+          title: const Text('Zatwierdź zgłoszenia serwisowe'),
+        ),
+        body: StreamBuilder<List<ServiceRequestElement>>(
+          stream: _requests(reqRepo),
+          builder: (context, snapshot) {
+            if (snapshot.hasError) {
+              return Center(child: Text('Błąd danych\n${snapshot.error}'));
+            }
+            if (!snapshot.hasData) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final requests = snapshot.data!;
+            if (requests.isEmpty) {
+              return const Center(child: Text('Brak zgłoszeń'));
+            }
+            return ListView.builder(
+              itemCount: requests.length,
+              itemBuilder: (context, index) {
+                final req = requests[index];
+                return _RequestApprovalTile(
+                  request: req,
+                  employeeStream: empRepo.getEmployees(),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _RequestApprovalTile extends StatefulWidget {
+  final ServiceRequestElement request;
+  final Stream<List<Employee>> employeeStream;
+  const _RequestApprovalTile({
+    required this.request,
+    required this.employeeStream,
+  });
+
+  @override
+  State<_RequestApprovalTile> createState() => _RequestApprovalTileState();
+}
+
+class _RequestApprovalTileState extends State<_RequestApprovalTile> {
+  Set<String> _selected = {};
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<ServiceRequestApprovalCubit>();
+    final req = widget.request;
+    final order = req.orderNumber.isEmpty ? '(brak numeru)' : req.orderNumber;
+    return Card(
+      margin: const EdgeInsets.all(8),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(order, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: AppSpacing.sm),
+            Text(req.description),
+            const SizedBox(height: AppSpacing.sm),
+            EmployeePicker(
+              employeeStream: widget.employeeStream,
+              initialSelectedIds: _selected.toList(),
+              onSelectionChanged: (emps) {
+                setState(() => _selected = emps.map((e) => e.uid).toSet());
+              },
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: _selected.isEmpty
+                    ? null
+                    : () => cubit.approveRequest(req, _selected.toList()),
+                child: const Text('Zatwierdź'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+
+class ServiceRequestApprovalState {
+  final bool isSubmitting;
+  final bool success;
+  final String? errorMsg;
+
+  ServiceRequestApprovalState({
+    required this.isSubmitting,
+    required this.success,
+    this.errorMsg,
+  });
+
+  factory ServiceRequestApprovalState.initial() =>
+      ServiceRequestApprovalState(isSubmitting: false, success: false);
+
+  ServiceRequestApprovalState copyWith({
+    bool? isSubmitting,
+    bool? success,
+    String? errorMsg,
+  }) {
+    return ServiceRequestApprovalState(
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      success: success ?? this.success,
+      errorMsg: errorMsg,
+    );
+  }
+}
+
+class ServiceRequestApprovalCubit
+    extends Cubit<ServiceRequestApprovalState> {
+  final GrafikElementRepository _grafikRepo;
+  final TaskAssignmentRepository _assignmentRepo;
+  final ServiceRequestRepository _requestRepo;
+
+  ServiceRequestApprovalCubit(
+    this._grafikRepo,
+    this._assignmentRepo,
+    this._requestRepo,
+  ) : super(ServiceRequestApprovalState.initial());
+
+  Future<void> approveRequest(
+    ServiceRequestElement request,
+    List<String> workerIds,
+  ) async {
+    emit(state.copyWith(isSubmitting: true, success: false, errorMsg: null));
+    final taskId = _grafikRepo.generateNewTaskId();
+    final task = request.toTaskElement().copyWithId(taskId);
+    try {
+      await _grafikRepo.saveGrafikElement(task);
+      for (final id in workerIds) {
+        final assignment = TaskAssignment(
+          taskId: taskId,
+          workerId: id,
+          startDateTime: task.startDateTime,
+          endDateTime: task.endDateTime,
+        );
+        await _assignmentRepo.saveTaskAssignment(assignment);
+      }
+      await _requestRepo.deleteServiceRequest(request.id);
+      emit(state.copyWith(isSubmitting: false, success: true));
+    } catch (e) {
+      emit(state.copyWith(
+        isSubmitting: false,
+        success: false,
+        errorMsg: e.toString(),
+      ));
+    }
+  }
+}

--- a/test/feature/service/service_request_approval_screen_test.dart
+++ b/test/feature/service/service_request_approval_screen_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+
+import 'package:kabast/feature/service/screens/service_request_approval_screen.dart';
+import 'package:kabast/data/repositories/grafik_element_repository.dart';
+import 'package:kabast/data/repositories/task_assignment_repository.dart';
+import 'package:kabast/data/repositories/service_request_repository.dart';
+import 'package:kabast/data/repositories/employee_repository.dart';
+import 'package:kabast/domain/services/i_grafik_element_service.dart';
+import 'package:kabast/domain/services/i_task_assignment_service.dart';
+import 'package:kabast/domain/services/i_service_request_service.dart';
+import 'package:kabast/domain/services/i_employee_service.dart';
+import 'package:kabast/domain/models/grafik/impl/service_request_element.dart';
+import 'package:kabast/domain/models/grafik/task_assignment.dart';
+import 'package:kabast/domain/models/employee.dart';
+
+class _DummyGrafikService implements IGrafikElementService {
+  @override
+  noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class FakeGrafikElementRepository extends GrafikElementRepository {
+  FakeGrafikElementRepository() : super(_DummyGrafikService());
+  GrafikElement? saved;
+  @override
+  Future<void> saveGrafikElement(GrafikElement element) async {
+    saved = element;
+  }
+
+  @override
+  String generateNewTaskId() => 't1';
+}
+
+class _DummyAssignmentService implements ITaskAssignmentService {
+  @override
+  noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class FakeTaskAssignmentRepository extends TaskAssignmentRepository {
+  FakeTaskAssignmentRepository() : super(_DummyAssignmentService());
+  final List<TaskAssignment> saved = [];
+  @override
+  Future<void> saveTaskAssignment(TaskAssignment assignment) async {
+    saved.add(assignment);
+  }
+}
+
+class _FakeServiceRequestService implements IServiceRequestService {
+  final Stream<List<ServiceRequestElement>> _stream;
+  String? deleted;
+  _FakeServiceRequestService(this._stream);
+  @override
+  Stream<List<ServiceRequestElement>> watchServiceRequests() => _stream;
+  @override
+  Future<void> upsertServiceRequest(ServiceRequestElement request) async {}
+  @override
+  Future<void> deleteServiceRequest(String id) async {
+    deleted = id;
+  }
+}
+
+class FakeServiceRequestRepository extends ServiceRequestRepository {
+  final _FakeServiceRequestService impl;
+  FakeServiceRequestRepository(Stream<List<ServiceRequestElement>> stream)
+      : impl = _FakeServiceRequestService(stream),
+        super(_FakeServiceRequestService(stream));
+  @override
+  Stream<List<ServiceRequestElement>> watchServiceRequests() => impl.watchServiceRequests();
+  @override
+  Future<void> deleteServiceRequest(String id) => impl.deleteServiceRequest(id);
+}
+
+class _DummyEmployeeService implements IEmployeeService {
+  @override
+  Stream<List<Employee>> getEmployeesStream() =>
+      Stream.value([Employee(uid: 'e1', role: 'r', fullName: 'Foo Bar')]);
+  @override
+  Future<void> upsertEmployee(Employee employee) async {}
+}
+
+class FakeEmployeeRepository extends EmployeeRepository {
+  FakeEmployeeRepository() : super(_DummyEmployeeService());
+}
+
+void main() {
+  testWidgets('approves request and saves assignments', (tester) async {
+    final req = ServiceRequestElement(
+      id: 'r1',
+      createdBy: 'u1',
+      createdAt: DateTime(2024, 1, 1),
+      location: 'loc',
+      description: 'desc',
+      orderNumber: 'o1',
+      estimatedDuration: const Duration(minutes: 60),
+      requiredPeopleCount: 1,
+    );
+
+    final reqRepo = FakeServiceRequestRepository(Stream.value([req]));
+    final grafikRepo = FakeGrafikElementRepository();
+    final assignRepo = FakeTaskAssignmentRepository();
+    final empRepo = FakeEmployeeRepository();
+
+    GetIt.I.registerSingleton<ServiceRequestRepository>(reqRepo);
+    GetIt.I.registerSingleton<GrafikElementRepository>(grafikRepo);
+    GetIt.I.registerSingleton<TaskAssignmentRepository>(assignRepo);
+    GetIt.I.registerSingleton<EmployeeRepository>(empRepo);
+
+    await tester.pumpWidget(const MaterialApp(home: ServiceRequestApprovalScreen()));
+    await tester.pump();
+
+    expect(find.text('o1'), findsOneWidget);
+
+    await tester.tap(find.text('Foo'));
+    await tester.pump();
+    await tester.tap(find.text('Zatwierdź'));
+    await tester.pumpAndSettle();
+
+    expect(grafikRepo.saved, isNotNull);
+    expect(assignRepo.saved.length, 1);
+    expect(reqRepo.impl.deleted, 'r1');
+
+    GetIt.I.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- implement `ServiceRequestApprovalScreen` with employee selection
- register new route `/approveServiceRequests`
- test approving a service request

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836d5b1a3883338d89864a4d63c47d