### PR TITLE
Add service request approval menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ flutter doctor
 
 Then run `flutter analyze` in the repository root.
 
+The `/approveServiceRequests` route is used for approving service task
+requests in the app.
+

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -17,6 +17,12 @@ By default this permission is enabled for the `admin`, `kierownik` and
 `kierownikProdukcji` roles.  Accessing the `/approveSupplyRuns` route requires
 this permission.
 
+## Service request approval
+
+Service requests can be approved by users that have the `canEditGrafik`
+permission. The approval screen lives at `/approveServiceRequests` and becomes
+available as a menu action in the service request list for those users.
+
 ## Example
 
 Initially users were routed directly to specific screens based on permissions.

--- a/feature/service/screens/service_request_list_screen.dart
+++ b/feature/service/screens/service_request_list_screen.dart
@@ -37,6 +37,16 @@ class ServiceRequestListScreen extends StatelessWidget {
       drawer: const AppDrawer(),
       appBar: AppBar(
         title: const Text('Zlecenia serwisowe'),
+        actions: [
+          PermissionWidget(
+            permission: 'canEditGrafik',
+            child: IconButton(
+              icon: const Icon(Icons.check),
+              onPressed: () =>
+                  Navigator.pushNamed(context, '/approveServiceRequests'),
+            ),
+          ),
+        ],
       ),
       body: StreamBuilder<List<ServiceRequestElement>>(
         stream: _openRequests(repo),


### PR DESCRIPTION
## Summary
- allow access to approve service requests from the request list
- document `/approveServiceRequests` route

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883785d04b08333a49ea2f1f89c9b61