### PR TITLE
Add docs for service request approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ Then run `flutter analyze` in the repository root.
 The `/approveServiceRequests` route is used for approving service task
 requests in the app.
 
+
+## Approving service requests
+
+1. Navigate to `/approveServiceRequests` to view pending entries.
+2. Select workers and confirm approval.
+3. The app creates a task in the `task_elements_v2` collection and updates the original record in `service_requests` with `status: approved` and `taskId` of the created task.
+4. Example documents are shown in `docs/service_requests.md`.

--- a/docs/service_requests.md
+++ b/docs/service_requests.md
@@ -1,0 +1,58 @@
+# Service Request Approval Data
+
+This document shows example Firestore documents before and after approving a service request and the task created as a result.
+
+## Pending `service_requests` entry
+
+```json
+{
+  "id": "req1",
+  "startDateTime": "2024-04-25T10:00:00.000Z",
+  "endDateTime": "2024-04-25T12:00:00.000Z",
+  "type": "ServiceRequestElement",
+  "additionalInfo": "Hydraulic leak check",
+  "addedByUserId": "u1",
+  "addedTimestamp": "2024-04-23T09:00:00.000Z",
+  "closed": false,
+  "location": "Hall A",
+  "description": "Przeciek w maszynie X",
+  "orderNumber": "PO-42",
+  "urgency": "normal",
+  "suggestedDate": "2024-04-25T10:00:00.000Z",
+  "estimatedDuration": 120,
+  "requiredPeopleCount": 2,
+  "taskType": "Serwis",
+  "status": "pending",
+  "taskId": null
+}
+```
+
+## After approval
+
+The same document gets its status updated and receives a reference to the created task:
+
+```json
+{
+  "status": "approved",
+  "taskId": "task123"
+}
+```
+
+## Resulting `task_elements_v2` entry
+
+```json
+{
+  "id": "task123",
+  "startDateTime": "2024-04-25T10:00:00.000Z",
+  "endDateTime": "2024-04-25T12:00:00.000Z",
+  "type": "TaskElement",
+  "additionalInfo": "Hydraulic leak check",
+  "addedByUserId": "u1",
+  "addedTimestamp": "2024-04-23T09:00:00.000Z",
+  "closed": false,
+  "orderId": "PO-42",
+  "status": "Realizacja",
+  "taskType": "Serwis",
+  "carIds": []
+}
+```


### PR DESCRIPTION
## Summary
- document example service request pending/approved records
- add resulting `task_elements_v2` example
- summarize approval flow in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837c624fcc8333ae5e0a0e0a56e9e1