### PR TITLE
Handle service form permission

### DIFF
--- a/feature/service/screens/service_request_form_screen.dart
+++ b/feature/service/screens/service_request_form_screen.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 
 import '../../../data/repositories/service_request_repository.dart';
 import '../../auth/auth_cubit.dart';
+import '../../auth/screen/no_access_screen.dart';
 import '../cubit/service_request_form_cubit.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
@@ -16,6 +17,13 @@ class ServiceRequestFormScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final user = context.watch<AuthCubit>().currentUser;
+    final hasPermission =
+        user?.effectivePermissions['canCreateServiceTasks'] ?? false;
+    if (user == null || !hasPermission) {
+      return const NoAccessScreen();
+    }
+
     return BlocProvider(
       create: (_) => ServiceRequestFormCubit(
         GetIt.I<ServiceRequestRepository>(),

--- a/test/feature/service/service_request_form_screen_test.dart
+++ b/test/feature/service/service_request_form_screen_test.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:kabast/feature/service/screens/service_request_form_screen.dart';
+import 'package:kabast/feature/auth/auth_cubit.dart';
+import 'package:kabast/feature/auth/screen/no_access_screen.dart';
 import 'package:kabast/data/repositories/service_request_repository.dart';
 import 'package:kabast/domain/services/i_service_request_service.dart';
+import 'package:kabast/domain/services/i_auth_service.dart';
+import 'package:kabast/domain/models/app_user.dart';
 import 'package:kabast/domain/models/grafik/impl/service_request_element.dart';
 import 'package:kabast/domain/models/grafik/enums.dart';
 
@@ -20,13 +25,46 @@ class _FakeService implements IServiceRequestService {
   Future<void> deleteServiceRequest(String id) async {}
 }
 
+class FakeAuthService implements IAuthService {
+  final AppUser? user;
+  FakeAuthService(this.user);
+
+  @override
+  Stream<AppUser?> authStateChanges() => Stream.value(user);
+
+  @override
+  Future<void> signUp(String email, String password) async {}
+
+  @override
+  Future<void> signIn(String email, String password) async {}
+
+  @override
+  Future<void> signOut() async {}
+}
+
 void main() {
   testWidgets('fill form and save', (tester) async {
     final service = _FakeService();
     final repo = ServiceRequestRepository(service);
     GetIt.I.registerSingleton<ServiceRequestRepository>(repo);
 
-    await tester.pumpWidget(const MaterialApp(home: ServiceRequestFormScreen()));
+    final user = AppUser(
+      id: 'u1',
+      email: 'e',
+      fullName: 'f',
+      employeeId: '',
+      role: UserRole.kierownik,
+      permissionsOverride: const {},
+    );
+    final authCubit = AuthCubit(FakeAuthService(user));
+
+    await tester.pumpWidget(
+      BlocProvider<AuthCubit>.value(
+        value: authCubit,
+        child: const MaterialApp(home: ServiceRequestFormScreen()),
+      ),
+    );
+    await tester.pump();
 
     await tester.enterText(find.bySemanticsLabel('Lokalizacja'), 'loc');
     await tester.enterText(find.bySemanticsLabel('Nr zlecenia'), 'o1');
@@ -40,5 +78,35 @@ void main() {
     expect(service.saved!.description, 'desc');
 
     GetIt.I.reset();
+    await authCubit.close();
+  });
+
+  testWidgets('denies access when permission missing', (tester) async {
+    final service = _FakeService();
+    final repo = ServiceRequestRepository(service);
+    GetIt.I.registerSingleton<ServiceRequestRepository>(repo);
+
+    final user = AppUser(
+      id: 'u2',
+      email: 'e2',
+      fullName: 'f2',
+      employeeId: '',
+      role: UserRole.user,
+      permissionsOverride: const {},
+    );
+    final authCubit = AuthCubit(FakeAuthService(user));
+
+    await tester.pumpWidget(
+      BlocProvider<AuthCubit>.value(
+        value: authCubit,
+        child: const MaterialApp(home: ServiceRequestFormScreen()),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(NoAccessScreen), findsOneWidget);
+
+    GetIt.I.reset();
+    await authCubit.close();
   });
 }


### PR DESCRIPTION
## Summary
- check AuthCubit's permissions in the service request form screen
- show `NoAccessScreen` if user can't create tasks
- extend widget tests to cover access denial

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878c52fde883339fd0624a833ca543