### PR TITLE
Allow creator to view service request details

### DIFF
--- a/feature/service/screens/service_request_details_screen.dart
+++ b/feature/service/screens/service_request_details_screen.dart
@@ -5,6 +5,7 @@ import 'package:get_it/get_it.dart';
 import '../../../data/repositories/service_request_repository.dart';
 import '../../../domain/models/grafik/impl/service_request_element.dart';
 import '../../auth/auth_cubit.dart';
+import '../../auth/screen/no_access_screen.dart';
 import '../cubit/service_request_details_cubit.dart';
 import '../../../shared/form/custom_textfield.dart';
 import '../../../shared/form/enum_picker/enum_picker.dart';
@@ -35,9 +36,16 @@ class _ServiceRequestDetailsView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final canEdit = context.select<AuthCubit, bool>((cubit) =>
-        cubit.currentUser?.effectivePermissions['canEditServiceRequests'] ??
-        false);
+    final user = context.watch<AuthCubit>().currentUser;
+    final canEdit =
+        user?.effectivePermissions['canEditServiceRequests'] ?? false;
+    final canView =
+        user?.effectivePermissions['canViewServiceTasks'] ?? false;
+    final addedBy = context
+        .select<ServiceRequestDetailsCubit, String>((cubit) => cubit.state.createdBy);
+    if (user == null || !(canView || user.id == addedBy)) {
+      return const NoAccessScreen();
+    }
     return BlocListener<ServiceRequestDetailsCubit, ServiceRequestDetailsState>(
       listener: (context, state) {
         if (state.success) {

--- a/test/feature/service/service_request_details_screen_test.dart
+++ b/test/feature/service/service_request_details_screen_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:kabast/feature/service/screens/service_request_details_screen.dart';
+import 'package:kabast/feature/auth/auth_cubit.dart';
+import 'package:kabast/feature/auth/screen/no_access_screen.dart';
+import 'package:kabast/data/repositories/service_request_repository.dart';
+import 'package:kabast/domain/services/i_service_request_service.dart';
+import 'package:kabast/domain/services/i_auth_service.dart';
+import 'package:kabast/domain/models/app_user.dart';
+import 'package:kabast/domain/models/grafik/impl/service_request_element.dart';
+import 'package:kabast/domain/models/grafik/enums.dart';
+
+class _FakeService implements IServiceRequestService {
+  @override
+  Stream<List<ServiceRequestElement>> watchServiceRequests() => const Stream.empty();
+  @override
+  Future<void> upsertServiceRequest(ServiceRequestElement request) async {}
+  @override
+  Future<void> deleteServiceRequest(String id) async {}
+}
+
+class FakeAuthService implements IAuthService {
+  final AppUser? user;
+  FakeAuthService(this.user);
+
+  @override
+  Stream<AppUser?> authStateChanges() => Stream.value(user);
+
+  @override
+  Future<void> signUp(String email, String password) async {}
+
+  @override
+  Future<void> signIn(String email, String password) async {}
+
+  @override
+  Future<void> signOut() async {}
+}
+
+void main() {
+  testWidgets('creator can view request', (tester) async {
+    final repo = ServiceRequestRepository(_FakeService());
+    GetIt.I.registerSingleton<ServiceRequestRepository>(repo);
+
+    final request = ServiceRequestElement(
+      id: 'r1',
+      createdBy: 'u1',
+      createdAt: DateTime(2024, 1, 1),
+      location: 'loc',
+      description: 'desc',
+      orderNumber: 'o1',
+      estimatedDuration: const Duration(minutes: 60),
+      requiredPeopleCount: 1,
+    );
+
+    final user = AppUser(
+      id: 'u1',
+      email: 'e',
+      fullName: 'f',
+      employeeId: '',
+      role: UserRole.user,
+      permissionsOverride: const {},
+    );
+    final authCubit = AuthCubit(FakeAuthService(user));
+
+    await tester.pumpWidget(
+      BlocProvider<AuthCubit>.value(
+        value: authCubit,
+        child: MaterialApp(
+          home: ServiceRequestDetailsScreen(request: request),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(NoAccessScreen), findsNothing);
+    expect(find.text('desc'), findsOneWidget);
+
+    GetIt.I.reset();
+    await authCubit.close();
+  });
+}


### PR DESCRIPTION
## Summary
- restrict service request details with NoAccessScreen for non-creators
- allow creators to view their request even without `canViewServiceTasks`
- test the creator-can-view scenario

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878f5b0f2c8333a6f96573a9a9388c