### PR TITLE
Update service request approval doc

### DIFF
--- a/docs/roles.md
+++ b/docs/roles.md
@@ -19,11 +19,11 @@ this permission.
 
 ## Service request approval
 
-Service requests can be approved by users that have the
-`canApproveServiceTasks` permission. By default this is granted to the `admin`,
-`kierownik` and `kierownikProdukcji` roles. The approval screen lives at
-`/approveServiceRequests` and becomes available as a menu action in the service
-request list for those users.
+Approving a service request now requires the `canApproveServiceTasks`
+permission (previously handled via `canEditGrafik`). This permission is enabled
+by default for the `admin`, `kierownik` and `kierownikProdukcji` roles. The
+approval screen lives at `/approveServiceRequests` and becomes available as a
+menu action in the service request list for those users.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- clarify that service request approval uses `canApproveServiceTasks`
- note which roles hold this permission by default

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a2190efc8333a0ca868ad216a036