### PR TITLE
Add transport plan to tasks mapping

### DIFF
--- a/lib/domain/models/supplies/transport_plan_to_task_extension.dart
+++ b/lib/domain/models/supplies/transport_plan_to_task_extension.dart
@@ -1,0 +1,70 @@
+import '../../../../domain/models/supplies/transport_plan.dart';
+import '../../../../domain/models/grafik/impl/task_element.dart';
+import '../../../../domain/models/grafik/enums.dart';
+
+/// Conversion from [TransportPlan] to a list of [TaskElement]s.
+extension TransportPlanToTaskElements on TransportPlan {
+  /// Map this transport plan into task elements.
+  ///
+  /// Each dated subtask becomes its own [TaskElement]. When the plan
+  /// spans the whole day and subtasks lack dates, a single summarised
+  /// task element is returned instead.
+  List<TaskElement> toTaskElements() {
+    final dated = subtasks.where((t) => t.dateTime != null).toList();
+
+    if (dated.isEmpty && _isWholeDay()) {
+      final summaryParts = <String>[];
+      if (comment.isNotEmpty) summaryParts.add(comment);
+      summaryParts.addAll(subtasks.map(_formatSubtask));
+      final summary = summaryParts.join('; ');
+
+      return [
+        TaskElement(
+          id: '',
+          startDateTime: start,
+          endDateTime: end,
+          additionalInfo: summary,
+          orderId: '',
+          status: GrafikStatus.Realizacja,
+          taskType: GrafikTaskType.Zaopatrzenie,
+          carIds: const [],
+          addedByUserId: createdBy,
+          addedTimestamp: DateTime.now(),
+          closed: closed,
+        )
+      ];
+    }
+
+    return dated.map((st) {
+      return TaskElement(
+        id: '',
+        startDateTime: st.dateTime!,
+        endDateTime: st.dateTime!,
+        additionalInfo: _formatSubtask(st),
+        orderId: st.relatedOrderId ?? '',
+        status: GrafikStatus.Realizacja,
+        taskType: GrafikTaskType.Zaopatrzenie,
+        carIds: const [],
+        addedByUserId: createdBy,
+        addedTimestamp: DateTime.now(),
+        closed: closed,
+      );
+    }).toList();
+  }
+
+  bool _isWholeDay() {
+    final sameDay = start.year == end.year &&
+        start.month == end.month &&
+        start.day == end.day;
+    return sameDay &&
+        start.hour == 0 &&
+        start.minute == 0 &&
+        end.hour == 23 &&
+        end.minute >= 59;
+  }
+
+  String _formatSubtask(TransportSubTask t) {
+    final note = (t.note == null || t.note!.isEmpty) ? '' : ' - ${t.note}';
+    return '${t.type.name} @ ${t.place}$note';
+  }
+}

--- a/test/domain/supplies/transport_plan_to_task_extension_test.dart
+++ b/test/domain/supplies/transport_plan_to_task_extension_test.dart
@@ -1,0 +1,77 @@
+import 'package:test/test.dart';
+
+import '../../../domain/models/supplies/transport_plan.dart';
+import '../../../lib/domain/models/supplies/transport_plan_to_task_extension.dart';
+import '../../../domain/models/grafik/impl/task_element.dart';
+import '../../../domain/models/grafik/enums.dart';
+
+void main() {
+  group('TransportPlan toTaskElements', () {
+    test('maps dated subtasks to task elements', () {
+      final plan = TransportPlan(
+        id: 'p1',
+        createdBy: 'u1',
+        start: DateTime(2024, 1, 1),
+        end: DateTime(2024, 1, 1, 23, 59),
+        subtasks: [
+          TransportSubTask(
+            type: TransportSubTaskType.purchase,
+            place: 'Store',
+            dateTime: DateTime(2024, 1, 1, 8),
+            relatedOrderId: 'o1',
+          ),
+          TransportSubTask(
+            type: TransportSubTaskType.delivery,
+            place: 'Site',
+            dateTime: DateTime(2024, 1, 1, 12),
+            note: 'fragile',
+            relatedOrderId: 'o2',
+          ),
+        ],
+        comment: 'daily',
+      );
+
+      final tasks = plan.toTaskElements();
+
+      expect(tasks, hasLength(2));
+
+      final first = tasks.first;
+      expect(first.startDateTime, DateTime(2024, 1, 1, 8));
+      expect(first.endDateTime, DateTime(2024, 1, 1, 8));
+      expect(first.orderId, 'o1');
+      expect(first.taskType, GrafikTaskType.Zaopatrzenie);
+      expect(first.status, GrafikStatus.Realizacja);
+      expect(first.addedByUserId, plan.createdBy);
+    });
+
+    test('summarizes full-day plan with undated subtasks', () {
+      final plan = TransportPlan(
+        id: 'p2',
+        createdBy: 'u2',
+        start: DateTime(2024, 2, 1),
+        end: DateTime(2024, 2, 1, 23, 59),
+        subtasks: [
+          TransportSubTask(
+            type: TransportSubTaskType.pickup,
+            place: 'A',
+          ),
+          TransportSubTask(
+            type: TransportSubTaskType.delivery,
+            place: 'B',
+          ),
+        ],
+        comment: 'rounds',
+      );
+
+      final tasks = plan.toTaskElements();
+
+      expect(tasks, hasLength(1));
+      final t = tasks.single;
+      expect(t.startDateTime, plan.start);
+      expect(t.endDateTime, plan.end);
+      expect(t.additionalInfo.contains('rounds'), isTrue);
+      expect(t.additionalInfo.contains('pickup'), isTrue);
+      expect(t.taskType, GrafikTaskType.Zaopatrzenie);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add extension to convert `TransportPlan` to task elements
- test the conversion logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b1df8f20833396662a4f36287c71