### PR TITLE
Add TransportPlan support

### DIFF
--- a/domain/models/grafik/impl/transport_plan.dart
+++ b/domain/models/grafik/impl/transport_plan.dart
@@ -1,0 +1,53 @@
+import '../grafik_element.dart';
+import '../../supplies/transport_plan.dart' as base;
+
+class TransportPlan extends GrafikElement {
+  final List<base.TransportSubTask> subtasks;
+  final String comment;
+  final String createdBy;
+
+  TransportPlan({
+    required String id,
+    required DateTime startDateTime,
+    required DateTime endDateTime,
+    required this.createdBy,
+    this.subtasks = const [],
+    this.comment = '',
+    required String addedByUserId,
+    required DateTime addedTimestamp,
+    bool closed = false,
+  }) : super(
+          id: id,
+          startDateTime: startDateTime,
+          endDateTime: endDateTime,
+          type: 'TransportPlan',
+          additionalInfo: comment,
+          addedByUserId: addedByUserId,
+          addedTimestamp: addedTimestamp,
+          closed: closed,
+        );
+
+  TransportPlan copyWith({
+    String? id,
+    DateTime? startDateTime,
+    DateTime? endDateTime,
+    String? createdBy,
+    List<base.TransportSubTask>? subtasks,
+    String? comment,
+    String? addedByUserId,
+    DateTime? addedTimestamp,
+    bool? closed,
+  }) {
+    return TransportPlan(
+      id: id ?? this.id,
+      startDateTime: startDateTime ?? this.startDateTime,
+      endDateTime: endDateTime ?? this.endDateTime,
+      createdBy: createdBy ?? this.createdBy,
+      subtasks: subtasks ?? List<base.TransportSubTask>.from(this.subtasks),
+      comment: comment ?? this.comment,
+      addedByUserId: addedByUserId ?? this.addedByUserId,
+      addedTimestamp: addedTimestamp ?? this.addedTimestamp,
+      closed: closed ?? this.closed,
+    );
+  }
+}

--- a/feature/grafik/constants/element_styles.dart
+++ b/feature/grafik/constants/element_styles.dart
@@ -42,6 +42,11 @@ class GrafikElementStyleResolver {
           borderColor: Color(0xFF8A6C4F),
           badgeIcon: Icons.shopping_cart,
         );
+      case 'TransportPlan':
+        return GrafikElementStyle(
+          backgroundColor: Colors.brown.shade100,
+          borderColor: Colors.brown,
+        );
       case 'TimeIssueElement':
         return GrafikElementStyle(
           backgroundColor: Colors.red.shade100,

--- a/feature/grafik/cubit/grafik_cubit.dart
+++ b/feature/grafik/cubit/grafik_cubit.dart
@@ -15,6 +15,7 @@ import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../../domain/models/grafik/impl/transport_plan.dart';
 import '../../../domain/models/vehicle.dart';
 import '../../../domain/models/grafik/task_assignment.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -88,7 +89,12 @@ class GrafikCubit extends Cubit<GrafikState> {
               _grafikRepo.getElementsWithinRange(
                 start: start,
                 end: end,
-                types: ['TaskElement', 'TimeIssueElement', 'SupplyRunElement'],
+                types: [
+                  'TaskElement',
+                  'TimeIssueElement',
+                  'SupplyRunElement',
+                  'TransportPlan'
+                ],
               ),
               _employeeRepo.getEmployees(),
               _taskAssignmentRepo.getAssignmentsWithinRange(
@@ -107,6 +113,9 @@ class GrafikCubit extends Cubit<GrafikState> {
                     )
                     .toList();
 
+                final transportPlans =
+                    elements.whereType<TransportPlan>().toList();
+
                 final mapping = calculateTaskTimeIssueDisplayMapping(
                   tasks: tasks,
                   issues: issues,
@@ -124,6 +133,7 @@ class GrafikCubit extends Cubit<GrafikState> {
                   'tasks': tasks,
                   'issues': issues,
                   'supplyRuns': supplyRuns,
+                  'transportPlans': transportPlans,
                   'employees': employees,
                   'assignments': assignments,
                   'mapping': mapping,
@@ -140,6 +150,8 @@ class GrafikCubit extends Cubit<GrafikState> {
                       issues: combinedData['issues'] as List<TimeIssueElement>,
                       supplyRuns:
                           combinedData['supplyRuns'] as List<SupplyRunElement>,
+                      transportPlans: combinedData['transportPlans']
+                          as List<TransportPlan>,
                       employees: combinedData['employees'] as List<Employee>,
                       taskTimeIssueDisplayMapping:
                           combinedData['mapping'] as Map<String, List<String>>,
@@ -181,6 +193,7 @@ class GrafikCubit extends Cubit<GrafikState> {
         'TaskPlanningElement',
         'DeliveryPlanningElement',
         'SupplyRunElement',
+        'TransportPlan',
       ],
     );
 
@@ -213,6 +226,8 @@ class GrafikCubit extends Cubit<GrafikState> {
                         FirebaseAuth.instance.currentUser?.uid,
                   )
                   .toList();
+              final transportPlans =
+                  elements.whereType<TransportPlan>().toList();
 
               return {
                 'taskElements': taskElements,
@@ -220,21 +235,24 @@ class GrafikCubit extends Cubit<GrafikState> {
                 'taskPlannings': taskPlannings,
                 'deliveryPlanningElements': deliveryPlannings,
                 'supplyRuns': supplyRuns,
+                'transportPlans': transportPlans,
                 'employees': employees,
               };
             })
             .listen(
               (data) {
-                final updatedWeek = state.weekData.copyWith(
-                  taskElements: data['taskElements'] as List<TaskElement>,
-                  timeIssues: data['timeIssues'] as List<TimeIssueElement>,
-                  taskPlannings:
-                      data['taskPlannings'] as List<TaskPlanningElement>,
-                  deliveryPlannings:
-                      data['deliveryPlanningElements']
-                          as List<DeliveryPlanningElement>,
-                  supplyRuns: data['supplyRuns'] as List<SupplyRunElement>,
-                );
+              final updatedWeek = state.weekData.copyWith(
+                taskElements: data['taskElements'] as List<TaskElement>,
+                timeIssues: data['timeIssues'] as List<TimeIssueElement>,
+                taskPlannings:
+                    data['taskPlannings'] as List<TaskPlanningElement>,
+                deliveryPlannings:
+                    data['deliveryPlanningElements']
+                        as List<DeliveryPlanningElement>,
+                supplyRuns: data['supplyRuns'] as List<SupplyRunElement>,
+                transportPlans:
+                    data['transportPlans'] as List<TransportPlan>,
+              );
                 emit(
                   state.copyWith(
                     weekData: updatedWeek,

--- a/feature/grafik/cubit/grafik_state.dart
+++ b/feature/grafik/cubit/grafik_state.dart
@@ -1,6 +1,7 @@
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
+import 'package:kabast/domain/models/grafik/impl/transport_plan.dart';
 import 'package:kabast/domain/models/vehicle.dart';
 import 'package:kabast/domain/models/employee.dart';
 import 'package:kabast/domain/models/grafik/task_assignment.dart';
@@ -10,6 +11,7 @@ class GrafikState {
   final List<TaskElement> tasks;
   final List<TimeIssueElement> issues;
   final List<SupplyRunElement> supplyRuns;
+  final List<TransportPlan> transportPlans;
   final List<TaskAssignment> assignments;
   final Map<String, List<String>> taskTimeIssueDisplayMapping;
   final Map<String, List<String>> taskTransferDisplayMapping;
@@ -23,6 +25,7 @@ class GrafikState {
     required this.tasks,
     required this.issues,
     required this.supplyRuns,
+    required this.transportPlans,
     required this.taskTimeIssueDisplayMapping,
     required this.taskTransferDisplayMapping,
     required this.assignments,
@@ -37,6 +40,7 @@ class GrafikState {
       tasks: [],
       issues: [],
       supplyRuns: [],
+      transportPlans: [],
       taskTimeIssueDisplayMapping: {},
       taskTransferDisplayMapping: {},
       assignments: [],
@@ -51,6 +55,7 @@ class GrafikState {
     List<TaskElement>? tasks,
     List<TimeIssueElement>? issues,
     List<SupplyRunElement>? supplyRuns,
+    List<TransportPlan>? transportPlans,
     Map<String, List<String>>? taskTimeIssueDisplayMapping,
     Map<String, List<String>>? taskTransferDisplayMapping,
     List<TaskAssignment>? assignments,
@@ -63,6 +68,7 @@ class GrafikState {
       tasks: tasks ?? this.tasks,
       issues: issues ?? this.issues,
       supplyRuns: supplyRuns ?? this.supplyRuns,
+      transportPlans: transportPlans ?? this.transportPlans,
       taskTimeIssueDisplayMapping: taskTimeIssueDisplayMapping ?? this.taskTimeIssueDisplayMapping,
       taskTransferDisplayMapping: taskTransferDisplayMapping ?? this.taskTransferDisplayMapping,
       assignments: assignments ?? this.assignments,

--- a/feature/grafik/cubit/states/week_grafik_data.dart
+++ b/feature/grafik/cubit/states/week_grafik_data.dart
@@ -3,6 +3,7 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
+import 'package:kabast/domain/models/grafik/impl/transport_plan.dart';
 
 class WeekGrafikData {
   final List<TaskElement> taskElements;
@@ -10,6 +11,7 @@ class WeekGrafikData {
   final List<TaskPlanningElement> taskPlannings;
   final List<DeliveryPlanningElement> deliveryPlannings;
   final List<SupplyRunElement> supplyRuns;
+  final List<TransportPlan> transportPlans;
 
   WeekGrafikData({
     required this.taskElements,
@@ -17,6 +19,7 @@ class WeekGrafikData {
     required this.taskPlannings,
     required this.deliveryPlannings,
     required this.supplyRuns,
+    required this.transportPlans,
   });
 
   factory WeekGrafikData.initial() => WeekGrafikData(
@@ -25,6 +28,7 @@ class WeekGrafikData {
         taskPlannings: [],
         deliveryPlannings: [],
         supplyRuns: [],
+        transportPlans: [],
       );
 
   WeekGrafikData copyWith({
@@ -33,6 +37,7 @@ class WeekGrafikData {
     List<TaskPlanningElement>? taskPlannings,
     List<DeliveryPlanningElement>? deliveryPlannings,
     List<SupplyRunElement>? supplyRuns,
+    List<TransportPlan>? transportPlans,
   }) {
     return WeekGrafikData(
       taskElements: taskElements ?? this.taskElements,
@@ -40,6 +45,7 @@ class WeekGrafikData {
       taskPlannings: taskPlannings ?? this.taskPlannings,
       deliveryPlannings: deliveryPlannings ?? this.deliveryPlannings,
       supplyRuns: supplyRuns ?? this.supplyRuns,
+      transportPlans: transportPlans ?? this.transportPlans,
     );
   }
 }

--- a/feature/grafik/form/grafik_element_registry.dart
+++ b/feature/grafik/form/grafik_element_registry.dart
@@ -5,16 +5,19 @@ import 'task_element_fields.dart';
 import 'task_planning_element_fields.dart';
 import 'time_issue_element_fields.dart';
 import 'supply_run_element_fields.dart';
+import 'transport_plan_element_fields.dart';
 import 'strategy/delivery_planning_element_strategy.dart';
 import 'strategy/task_element_strategy.dart';
 import 'strategy/task_planning_element_strategy.dart';
 import 'strategy/time_issue_element_strategy.dart';
 import 'strategy/supply_run_element_strategy.dart';
+import 'strategy/transport_plan_element_strategy.dart';
 import '../../../domain/models/grafik/impl/delivery_planning_element.dart';
 import '../../../domain/models/grafik/impl/task_element.dart';
 import '../../../domain/models/grafik/impl/task_planning_element.dart';
 import '../../../domain/models/grafik/impl/time_issue_element.dart';
 import '../../../domain/models/grafik/impl/supply_run_element.dart';
+import '../../../domain/models/grafik/impl/transport_plan.dart';
 import '../../../domain/models/grafik/grafik_element.dart';
 import 'strategy/grafik_element_form_strategy.dart';
 
@@ -27,6 +30,7 @@ class GrafikElementRegistry {
     'TaskElement': (e) => TaskFields(element: e as TaskElement),
     'TaskPlanningElement': (e) => GrafikPlanningFields(element: e as TaskPlanningElement),
     'SupplyRunElement': (e) => SupplyRunFields(element: e as SupplyRunElement),
+    'TransportPlan': (e) => TransportPlanFields(element: e as TransportPlan),
   };
 
   static final Map<String, GrafikElementFormStrategy> _strategies = {
@@ -35,6 +39,7 @@ class GrafikElementRegistry {
     'TaskElement': TaskElementStrategy(),
     'TaskPlanningElement': TaskPlanningElementStrategy(),
     'SupplyRunElement': SupplyRunElementStrategy(),
+    'TransportPlan': TransportPlanElementStrategy(),
   };
 
 

--- a/feature/grafik/form/strategy/transport_plan_element_strategy.dart
+++ b/feature/grafik/form/strategy/transport_plan_element_strategy.dart
@@ -1,0 +1,52 @@
+import '../grafik_element_form_adapter.dart';
+import '../../../../data/repositories/grafik_element_repository.dart';
+import '../../../../injection.dart';
+import '../../../../domain/models/grafik/grafik_element.dart';
+import '../../../../domain/models/grafik/impl/transport_plan.dart';
+import '../../../../domain/models/grafik/impl/task_template.dart';
+import 'grafik_element_form_strategy.dart';
+import '../../../../data/repositories/task_assignment_repository.dart';
+import '../../../../domain/models/grafik/task_assignment.dart';
+
+class TransportPlanElementStrategy implements GrafikElementFormStrategy {
+  final GrafikElementFormAdapter _adapter =
+      GrafikElementFormAdapter(repo: getIt<GrafikElementRepository>());
+
+  @override
+  GrafikElement createDefault() {
+    final tomorrow = DateTime.now().add(const Duration(days: 1));
+    final start = DateTime(tomorrow.year, tomorrow.month, tomorrow.day, 7);
+    final end = DateTime(tomorrow.year, tomorrow.month, tomorrow.day, 15);
+    return TransportPlan(
+      id: '',
+      startDateTime: start,
+      endDateTime: end,
+      createdBy: '',
+      subtasks: const [],
+      comment: '',
+      addedByUserId: '',
+      addedTimestamp: DateTime.now(),
+      closed: false,
+    );
+  }
+
+  @override
+  GrafikElement updateField(GrafikElement element, String field, dynamic value) {
+    return _adapter.updateField(element, field, value);
+  }
+
+  @override
+  GrafikElement applyTemplate(GrafikElement element, TaskTemplate template) {
+    return element;
+  }
+
+  @override
+  Future<void> save(
+    GrafikElementRepository repo,
+    GrafikElement element, {
+    TaskAssignmentRepository? assignmentRepository,
+    List<TaskAssignment> assignments = const [],
+  }) async {
+    await repo.saveGrafikElement(element);
+  }
+}

--- a/feature/grafik/form/transport_plan_element_fields.dart
+++ b/feature/grafik/form/transport_plan_element_fields.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/models/supplies/transport_plan.dart';
+import '../../shared/form/custom_textfield.dart';
+import '../../shared/form/enum_picker/enum_picker.dart';
+import '../../theme/app_tokens.dart';
+import '../cubit/form/grafik_element_form_cubit.dart';
+
+class TransportPlanFields extends StatefulWidget {
+  final TransportPlan element;
+  const TransportPlanFields({Key? key, required this.element}) : super(key: key);
+
+  @override
+  State<TransportPlanFields> createState() => _TransportPlanFieldsState();
+}
+
+class _TransportPlanFieldsState extends State<TransportPlanFields> {
+  late List<TransportSubTask> subtasks;
+
+  @override
+  void initState() {
+    super.initState();
+    subtasks = List.from(widget.element.subtasks);
+  }
+
+  @override
+  void didUpdateWidget(covariant TransportPlanFields oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.element.subtasks != subtasks) {
+      subtasks = List.from(widget.element.subtasks);
+    }
+  }
+
+  void _notify() {
+    context.read<GrafikElementFormCubit>().updateField('subtasks', subtasks);
+  }
+
+  void _addSubtask() {
+    setState(() {
+      subtasks.add(TransportSubTask(type: TransportSubTaskType.other, place: ''));
+    });
+    _notify();
+  }
+
+  void _update(int index, TransportSubTask task) {
+    setState(() => subtasks[index] = task);
+    _notify();
+  }
+
+  void _remove(int index) {
+    setState(() => subtasks.removeAt(index));
+    _notify();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<GrafikElementFormCubit>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CustomTextField(
+          label: 'Komentarz',
+          initialValue: widget.element.comment,
+          onChanged: (v) => cubit.updateField('comment', v),
+        ),
+        const SizedBox(height: AppSpacing.sm * 2),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: subtasks.length,
+          itemBuilder: (context, index) {
+            final st = subtasks[index];
+            return _SubtaskEditor(
+              key: ValueKey(index),
+              subtask: st,
+              onChanged: (t) => _update(index, t),
+              onRemove: () => _remove(index),
+            );
+          },
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: ElevatedButton(
+            onPressed: _addSubtask,
+            child: const Text('Dodaj podzadanie'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SubtaskEditor extends StatelessWidget {
+  final TransportSubTask subtask;
+  final ValueChanged<TransportSubTask> onChanged;
+  final VoidCallback onRemove;
+
+  const _SubtaskEditor({
+    Key? key,
+    required this.subtask,
+    required this.onChanged,
+    required this.onRemove,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: AppSpacing.sm * 2),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          children: [
+            EnumPicker<TransportSubTaskType>(
+              label: 'Typ',
+              values: TransportSubTaskType.values,
+              initialValue: subtask.type,
+              onChanged: (val) => onChanged(subtask.copyWith(type: val)),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            CustomTextField(
+              label: 'Miejsce',
+              initialValue: subtask.place,
+              onChanged: (v) => onChanged(subtask.copyWith(place: v)),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            CustomTextField(
+              label: 'Data (ISO, opcjonalnie)',
+              initialValue:
+                  subtask.dateTime != null ? subtask.dateTime!.toIso8601String() : '',
+              onChanged: (v) => onChanged(
+                subtask.copyWith(
+                  dateTime: v.isEmpty ? null : DateTime.tryParse(v),
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            CustomTextField(
+              label: 'Powiązane zlecenie',
+              initialValue: subtask.relatedOrderId ?? '',
+              onChanged: (v) =>
+                  onChanged(subtask.copyWith(relatedOrderId: v.isEmpty ? null : v)),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            CustomTextField(
+              label: 'Notatka',
+              initialValue: subtask.note ?? '',
+              onChanged: (v) =>
+                  onChanged(subtask.copyWith(note: v.isEmpty ? null : v)),
+            ),
+            Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: onRemove,
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/feature/grafik/widget/week/foreground_layer.dart
+++ b/feature/grafik/widget/week/foreground_layer.dart
@@ -6,6 +6,7 @@ import 'package:kabast/domain/models/grafik/impl/delivery_planning_element.dart'
 import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
+import 'package:kabast/domain/models/grafik/impl/transport_plan.dart';
 import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/default_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/delivery_planning_week_tile.dart';
@@ -13,6 +14,7 @@ import 'package:kabast/feature/grafik/widget/week/tiles/task_planning_week_tile.
 import 'package:kabast/feature/grafik/widget/week/tiles/task_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/time_issue_week_tile.dart';
 import 'package:kabast/feature/grafik/widget/week/tiles/supply_run_week_tile.dart';
+import 'package:kabast/feature/grafik/widget/week/tiles/transport_plan_week_tile.dart';
 
 import '../../cubit/grafik_cubit.dart';
 import '../../cubit/grafik_state.dart';
@@ -82,6 +84,7 @@ class ForegroundLayer extends StatelessWidget {
           ...state.weekData.taskPlannings,
           ...state.weekData.deliveryPlannings,
           ...state.weekData.supplyRuns,
+          ...state.weekData.transportPlans,
           ...state.weekData.taskElements,
           ...state.weekData.timeIssues,
         ];
@@ -107,6 +110,11 @@ class ForegroundLayer extends StatelessWidget {
             } else if (elem is SupplyRunElement) {
               return SupplyRunWeekTile(
                 supplyRun: elem,
+                data: _supplyRunData(state),
+              );
+            } else if (elem is TransportPlan) {
+              return TransportPlanWeekTile(
+                plan: elem,
                 data: _supplyRunData(state),
               );
             } else if (elem is TaskElement) {

--- a/feature/grafik/widget/week/tiles/transport_plan_week_tile.dart
+++ b/feature/grafik/widget/week/tiles/transport_plan_week_tile.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:kabast/domain/models/supplies/transport_plan.dart';
+import 'package:kabast/domain/models/grafik/grafik_element_data.dart';
+import 'package:kabast/shared/grafik_element_card.dart';
+import 'package:kabast/shared/turbo_grid/turbo_grid.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_delegate.dart';
+import 'package:kabast/shared/turbo_grid/turbo_tile_variant.dart';
+
+import '../../../../../theme/size_variants.dart';
+
+class TransportPlanWeekTile extends StatelessWidget {
+  final TransportPlan plan;
+  final GrafikElementData data;
+
+  const TransportPlanWeekTile({
+    Key? key,
+    required this.plan,
+    required this.data,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final height = constraints.maxHeight;
+        return TurboGrid(
+          tiles: [
+            TurboTile(
+              priority: 1,
+              required: true,
+              delegate: _TransportPlanCardDelegate(plan, data, width, height),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _TransportPlanCardDelegate extends TurboTileDelegate {
+  final TransportPlan plan;
+  final GrafikElementData data;
+  final double width;
+  final double height;
+
+  _TransportPlanCardDelegate(this.plan, this.data, this.width, this.height);
+
+  @override
+  List<TurboTileVariant> createVariants() => [
+        _variant(SizeVariant.large),
+        _variant(SizeVariant.medium),
+        _variant(SizeVariant.small),
+        _variant(SizeVariant.mini),
+      ];
+
+  TurboTileVariant _variant(SizeVariant v) {
+    return TurboTileVariant(
+      size: Size(width, height),
+      builder: (context, constraints) => SizedBox.expand(
+        child: GrafikElementCard(
+          element: plan,
+          data: data,
+          variant: v,
+        ),
+      ),
+    );
+  }
+}

--- a/shared/grafik_card_delegate.dart
+++ b/shared/grafik_card_delegate.dart
@@ -4,6 +4,7 @@ import 'package:kabast/domain/models/grafik/impl/task_element.dart';
 import 'package:kabast/domain/models/grafik/impl/task_planning_element.dart';
 import 'package:kabast/domain/models/grafik/impl/time_issue_element.dart';
 import 'package:kabast/domain/models/grafik/impl/supply_run_element.dart';
+import 'package:kabast/domain/models/grafik/impl/transport_plan.dart';
 
 abstract class GrafikElementCardDelegate {
   String getLabel();
@@ -81,6 +82,24 @@ class TimeIssueElementCardDelegate implements GrafikElementCardDelegate {
   String getDescription() => issue.additionalInfo;
 }
 
+class TransportPlanCardDelegate implements GrafikElementCardDelegate {
+  final TransportPlan plan;
+  TransportPlanCardDelegate(this.plan);
+
+  @override
+  String getLabel() => plan.comment;
+
+  @override
+  String getTimeInfo() => _formatTime(plan.startDateTime, plan.endDateTime);
+
+  @override
+  String getDescription() {
+    return plan.subtasks
+        .map((e) => '${e.type.name} @ ${e.place}')
+        .join('; ');
+  }
+}
+
 class GrafikElementCardDelegateRegistry {
   static GrafikElementCardDelegate delegateFor(GrafikElement element) {
     switch (element.runtimeType) {
@@ -94,6 +113,8 @@ class GrafikElementCardDelegateRegistry {
         return SupplyRunElementCardDelegate(element as SupplyRunElement);
       case TimeIssueElement:
         return TimeIssueElementCardDelegate(element as TimeIssueElement);
+      case TransportPlan:
+        return TransportPlanCardDelegate(element as TransportPlan);
       default:
         throw ArgumentError('Unsupported element type');
     }


### PR DESCRIPTION
## Summary
- enable TransportPlan editing and display
- add strategy and form fields with subtask management
- show TransportPlan in week view
- support TransportPlan in Grafik cubit/state

## Testing
- `dart` was not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6887b3a5e8e88333991a93cea7efa21a