### PR TITLE
Add TransportPlan cubit and repository

### DIFF
--- a/data/repositories/transport_plan_repository.dart
+++ b/data/repositories/transport_plan_repository.dart
@@ -1,0 +1,15 @@
+import '../../domain/models/grafik/impl/transport_plan.dart' as grafik;
+import '../repositories/grafik_element_repository.dart';
+
+class TransportPlanRepository {
+  final GrafikElementRepository _grafikRepository;
+  TransportPlanRepository(this._grafikRepository);
+
+  Future<void> saveTransportPlan(grafik.TransportPlan plan) {
+    return _grafikRepository.saveGrafikElement(plan);
+  }
+
+  Future<void> deleteTransportPlan(String id) {
+    return _grafikRepository.deleteGrafikElement(id);
+  }
+}

--- a/feature/supplies/cubit/transport_plan_cubit.dart
+++ b/feature/supplies/cubit/transport_plan_cubit.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../data/repositories/transport_plan_repository.dart';
+import '../../../domain/models/supplies/transport_plan.dart';
+import '../../../domain/models/grafik/impl/transport_plan.dart' as grafik;
+import 'transport_plan_state.dart';
+
+class TransportPlanCubit extends Cubit<TransportPlanState> {
+  final TransportPlanRepository _repo;
+
+  TransportPlanCubit(this._repo, {TransportPlan? existing})
+      : super(existing != null
+            ? TransportPlanState.fromPlan(existing)
+            : TransportPlanState.initial());
+
+  void setStart(DateTime val) => emit(state.copyWith(start: val));
+  void setEnd(DateTime val) => emit(state.copyWith(end: val));
+  void setComment(String val) => emit(state.copyWith(comment: val));
+
+  void addSubtask(TransportSubTask task) {
+    final list = List<TransportSubTask>.from(state.subtasks)..add(task);
+    emit(state.copyWith(subtasks: list));
+  }
+
+  void updateSubtask(int index, TransportSubTask task) {
+    final list = List<TransportSubTask>.from(state.subtasks);
+    if (index >= 0 && index < list.length) {
+      list[index] = task;
+      emit(state.copyWith(subtasks: list));
+    }
+  }
+
+  void removeSubtask(int index) {
+    final list = List<TransportSubTask>.from(state.subtasks);
+    if (index >= 0 && index < list.length) {
+      list.removeAt(index);
+      emit(state.copyWith(subtasks: list));
+    }
+  }
+
+  Future<void> save(String userId) async {
+    emit(state.copyWith(isSubmitting: true, success: false, errorMsg: null));
+    final plan = grafik.TransportPlan(
+      id: state.id,
+      startDateTime: state.start,
+      endDateTime: state.end,
+      createdBy: userId,
+      subtasks: state.subtasks,
+      comment: state.comment,
+      addedByUserId: userId,
+      addedTimestamp: DateTime.now(),
+      closed: false,
+    );
+    try {
+      await _repo.saveTransportPlan(plan);
+      emit(state.copyWith(isSubmitting: false, success: true));
+    } catch (e) {
+      emit(state.copyWith(isSubmitting: false, success: false, errorMsg: e.toString()));
+    }
+  }
+
+  Future<void> delete() async {
+    if (state.id.isEmpty) return;
+    emit(state.copyWith(isSubmitting: true, success: false, errorMsg: null));
+    try {
+      await _repo.deleteTransportPlan(state.id);
+      emit(state.copyWith(isSubmitting: false, success: true));
+    } catch (e) {
+      emit(state.copyWith(isSubmitting: false, success: false, errorMsg: e.toString()));
+    }
+  }
+}

--- a/feature/supplies/cubit/transport_plan_state.dart
+++ b/feature/supplies/cubit/transport_plan_state.dart
@@ -1,0 +1,66 @@
+import '../../../domain/models/supplies/transport_plan.dart';
+
+class TransportPlanState {
+  final String id;
+  final DateTime start;
+  final DateTime end;
+  final List<TransportSubTask> subtasks;
+  final String comment;
+  final bool isSubmitting;
+  final bool success;
+  final String? errorMsg;
+
+  TransportPlanState({
+    required this.id,
+    required this.start,
+    required this.end,
+    required this.subtasks,
+    required this.comment,
+    this.isSubmitting = false,
+    this.success = false,
+    this.errorMsg,
+  });
+
+  factory TransportPlanState.initial() {
+    final now = DateTime.now();
+    return TransportPlanState(
+      id: '',
+      start: now.add(const Duration(hours: 1)),
+      end: now.add(const Duration(hours: 2)),
+      subtasks: const [],
+      comment: '',
+    );
+  }
+
+  factory TransportPlanState.fromPlan(TransportPlan plan) => TransportPlanState(
+        id: plan.id,
+        start: plan.start,
+        end: plan.end,
+        subtasks: List<TransportSubTask>.from(plan.subtasks),
+        comment: plan.comment,
+        isSubmitting: false,
+        success: false,
+      );
+
+  TransportPlanState copyWith({
+    String? id,
+    DateTime? start,
+    DateTime? end,
+    List<TransportSubTask>? subtasks,
+    String? comment,
+    bool? isSubmitting,
+    bool? success,
+    String? errorMsg,
+  }) {
+    return TransportPlanState(
+      id: id ?? this.id,
+      start: start ?? this.start,
+      end: end ?? this.end,
+      subtasks: subtasks ?? List<TransportSubTask>.from(this.subtasks),
+      comment: comment ?? this.comment,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      success: success ?? this.success,
+      errorMsg: errorMsg,
+    );
+  }
+}

--- a/injection.dart
+++ b/injection.dart
@@ -29,6 +29,8 @@ import 'package:kabast/domain/services/i_supply_repository.dart';
 import 'package:kabast/data/services/firebase/service_request_firebase_service.dart';
 import 'package:kabast/data/repositories/service_request_repository.dart';
 import 'package:kabast/domain/services/i_service_request_service.dart';
+import 'package:kabast/data/repositories/transport_plan_repository.dart';
+import 'package:kabast/feature/supplies/cubit/transport_plan_cubit.dart';
 
 
 import 'package:kabast/data/services/task_assignment_firebase_service.dart';
@@ -100,6 +102,9 @@ Future<void> setupLocator() async {
   getIt.registerLazySingleton<ServiceRequestRepository>(
     () => ServiceRequestRepository(getIt<IServiceRequestService>()),
   );
+  getIt.registerLazySingleton<TransportPlanRepository>(
+    () => TransportPlanRepository(getIt<GrafikElementRepository>()),
+  );
   getIt.registerLazySingleton<IGrafikResolver>(
     () => GrafikResolver(getIt<GrafikElementRepository>()),
   );
@@ -128,5 +133,8 @@ Future<void> setupLocator() async {
       getIt<TaskAssignmentRepository>(),
       getIt<DateCubit>(),
     ),
+  );
+  getIt.registerFactory<TransportPlanCubit>(
+    () => TransportPlanCubit(getIt<TransportPlanRepository>()),
   );
 }


### PR DESCRIPTION
## Summary
- add cubit and state for editing transport plans
- expose repository for saving/deleting transport plans
- register new classes in DI container

## Testing
- `apt-get update`
- `apt-cache search dart` *(fails to find dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6887b8b420008333bf56c8d4687cdc1c