### PR TITLE
Add Store model and repository

### DIFF
--- a/data/dto/store_dto.dart
+++ b/data/dto/store_dto.dart
@@ -1,0 +1,58 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/models/store.dart';
+
+class StoreDto {
+  final String id;
+  final String name;
+  final String defaultAddress;
+  final bool isDefaultListFlag;
+
+  StoreDto({
+    required this.id,
+    required this.name,
+    required this.defaultAddress,
+    required this.isDefaultListFlag,
+  });
+
+  factory StoreDto.fromJson(Map<String, dynamic> json) {
+    return StoreDto(
+      id: json['id'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      defaultAddress: json['defaultAddress'] as String? ?? '',
+      isDefaultListFlag: json['isDefaultListFlag'] as bool? ?? false,
+    );
+  }
+
+  factory StoreDto.fromFirestore(DocumentSnapshot doc) {
+    final data = (doc.data() as Map<String, dynamic>? ?? {})..putIfAbsent('id', () => doc.id);
+    return StoreDto.fromJson(data);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'defaultAddress': defaultAddress,
+      'isDefaultListFlag': isDefaultListFlag,
+    };
+  }
+
+  Store toDomain() {
+    return Store(
+      id: id,
+      name: name,
+      defaultAddress: defaultAddress,
+      isDefaultListFlag: isDefaultListFlag,
+    );
+  }
+
+  factory StoreDto.fromDomain(Store store) {
+    return StoreDto(
+      id: store.id,
+      name: store.name,
+      defaultAddress: store.defaultAddress,
+      isDefaultListFlag: store.isDefaultListFlag,
+    );
+  }
+}

--- a/data/repositories/store_repository.dart
+++ b/data/repositories/store_repository.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/models/store.dart';
+import '../dto/store_dto.dart';
+
+class StoreRepository {
+  final FirebaseFirestore _firestore;
+
+  StoreRepository(this._firestore);
+
+  CollectionReference get _stores => _firestore.collection('stores');
+
+  Stream<List<Store>> watchStores() {
+    return _stores.snapshots().map(
+          (query) =>
+              query.docs.map((doc) => StoreDto.fromFirestore(doc).toDomain()).toList(),
+        );
+  }
+
+  Future<void> saveStore(Store store) async {
+    final dto = StoreDto.fromDomain(store);
+    if (store.id.isEmpty) {
+      final ref = await _stores.add(dto.toJson());
+      await ref.update({'id': ref.id});
+    } else {
+      await _stores.doc(store.id).set(dto.toJson());
+    }
+  }
+}

--- a/domain/models/store.dart
+++ b/domain/models/store.dart
@@ -1,0 +1,13 @@
+class Store {
+  final String id;
+  final String name;
+  final String defaultAddress;
+  final bool isDefaultListFlag;
+
+  Store({
+    required this.id,
+    required this.name,
+    required this.defaultAddress,
+    required this.isDefaultListFlag,
+  });
+}

--- a/injection.dart
+++ b/injection.dart
@@ -26,6 +26,7 @@ import 'package:kabast/domain/services/i_grafik_element_service.dart';
 import 'package:kabast/data/repositories/supply_firebase_repository.dart';
 import 'package:kabast/data/repositories/supply_order_repository.dart';
 import 'package:kabast/domain/services/i_supply_repository.dart';
+import 'package:kabast/data/repositories/store_repository.dart';
 import 'package:kabast/data/services/firebase/service_request_firebase_service.dart';
 import 'package:kabast/data/repositories/service_request_repository.dart';
 import 'package:kabast/domain/services/i_service_request_service.dart';
@@ -101,6 +102,9 @@ Future<void> setupLocator() async {
   );
   getIt.registerLazySingleton<ServiceRequestRepository>(
     () => ServiceRequestRepository(getIt<IServiceRequestService>()),
+  );
+  getIt.registerLazySingleton<StoreRepository>(
+    () => StoreRepository(getIt<FirebaseFirestore>()),
   );
   getIt.registerLazySingleton<TransportPlanRepository>(
     () => TransportPlanRepository(getIt<GrafikElementRepository>()),


### PR DESCRIPTION
## Summary
- add `Store` domain model
- create DTO for stores with Firestore mapping
- implement `StoreRepository` for watching and saving stores
- register repository in `injection.dart`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887cbc1991c8333acb03066ca0db46d